### PR TITLE
Sign all upload/download URLs

### DIFF
--- a/supernote/server/app.py
+++ b/supernote/server/app.py
@@ -18,6 +18,7 @@ from .services.file import FileService
 from .services.schedule import ScheduleService
 from .services.state import StateService
 from .services.user import UserService
+from .utils.url_signer import UrlSigner
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +152,7 @@ def create_app(config: ServerConfig) -> web.Application:
     )
     app["user_service"] = user_service
     app["file_service"] = file_service
+    app["url_signer"] = UrlSigner(config.auth.secret_key)
     app["schedule_service"] = ScheduleService(session_manager)
     app["sync_locks"] = {}  # user -> (equipment_no, expiry_time)
 

--- a/supernote/server/routes/file.py
+++ b/supernote/server/routes/file.py
@@ -224,17 +224,16 @@ async def handle_upload_apply(request: web.Request) -> web.Response:
 
     req_data = FileUploadApplyLocalDTO.from_dict(await request.json())
     file_name = req_data.file_name
-    
-    file_service: FileService = request.app["file_service"]
+
     url_signer: UrlSigner = request.app["url_signer"]
 
     # Path to sign must match the route: /api/file/upload/data/{filename}
     encoded_name = urllib.parse.quote(file_name)
     path_to_sign = f"/api/file/upload/data/{encoded_name}"
-    
+
     # helper returns: /api/file/upload/data/{encoded_name}?signature=...
     signed_path = url_signer.sign(path_to_sign)
-    
+
     # Construct full URL using request scheme and host
     full_url = f"{request.scheme}://{request.host}{signed_path}"
 
@@ -250,6 +249,7 @@ async def handle_upload_apply(request: web.Request) -> web.Response:
             part_upload_url=full_url,
         ).to_dict()
     )
+
 
 # TODO: We should move to use the OSS endpoints for all of these urls:
 # *   `POST /api/oss/generate/upload/url`: Get Upload URL
@@ -393,10 +393,10 @@ async def handle_download_apply(request: web.Request) -> web.Response:
 
     # Generate signed download URL
     url_signer: UrlSigner = request.app["url_signer"]
-    
+
     encoded_id = urllib.parse.quote(info.id)
     path_to_sign = f"/api/file/download/data?path={encoded_id}"
-    
+
     # helper returns: /api/file/download/data?path={encoded_id}&signature=...
     signed_path = url_signer.sign(path_to_sign)
     download_url = f"{request.scheme}://{request.host}{signed_path}"

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -2,7 +2,6 @@ import asyncio
 import hashlib
 import logging
 import shutil
-import urllib.parse
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from pathlib import Path
 
@@ -15,7 +14,6 @@ from supernote.models.file import (
     EntriesVO,
     FileCopyLocalVO,
     FileMoveLocalVO,
-    FileUploadApplyLocalVO,
     FileUploadFinishLocalVO,
     RecycleFileListVO,
     RecycleFileVO,
@@ -259,25 +257,7 @@ class FileService:
                 last_update_time=node.update_time,
             )
 
-    def apply_upload(
-        self, user: str, file_name: str, equipment_no: str, host: str
-    ) -> FileUploadApplyLocalVO:
-        """Apply for upload by a specific user."""
-        # Note: Ideally, the upload URL should also contain user context if it's handled by a separate request
-        # But handle_upload_data currently might need to extract user from JWT or filename.
-        # Since we use filename in the URL, and handle_upload_data will extract user from request["user"].
-        encoded_name = urllib.parse.quote(file_name)
-        upload_url = f"http://{host}/api/file/upload/data/{encoded_name}"
 
-        return FileUploadApplyLocalVO(
-            equipment_no=equipment_no,
-            bucket_name="supernote-local",
-            inner_name=file_name,
-            x_amz_date="",
-            authorization="",
-            full_upload_url=upload_url,
-            part_upload_url=upload_url,
-        )
 
     async def finish_upload(
         self,

--- a/supernote/server/utils/url_signer.py
+++ b/supernote/server/utils/url_signer.py
@@ -34,7 +34,6 @@ import logging
 import time
 import urllib.parse
 import uuid
-from dataclasses import dataclass
 
 import jwt
 
@@ -109,22 +108,20 @@ class UrlSigner:
         if not (signatures := query_params.get("signature")):
             logger.info("No signature found in URL: %s", signed_url)
             return False
-        
+
         signature = signatures[0]
         try:
             payload = jwt.decode(
-                signature, 
-                self.secret_key, 
-                algorithms=[self.algorithm]
+                signature, self.secret_key, algorithms=[self.algorithm]
             )
         except jwt.ExpiredSignatureError:
             logger.info("Signature expired: %s", signed_url)
             return False
-        except jwt.InvalidTokenError as e:
+        except jwt.InvalidTokenError:
             logger.info("Invalid signature: %s", signed_url)
             return False
-        
-        # We reconstruct the URL *without* the signature param to compare 
+
+        # We reconstruct the URL *without* the signature param to compare
         # against what was signed (payload['path']).
         if not (expected_path := payload.get("path")):
             logger.info("No path found in payload: %s", payload)
@@ -132,9 +129,9 @@ class UrlSigner:
 
         if not signed_url.startswith(expected_path):
             logger.info(
-                "Signed path mismatch: signed path '%s' is not prefix of request '%s'", 
-                expected_path, 
-                signed_url
+                "Signed path mismatch: signed path '%s' is not prefix of request '%s'",
+                expected_path,
+                signed_url,
             )
             return False
 

--- a/tests/server/utils/test_url_signer.py
+++ b/tests/server/utils/test_url_signer.py
@@ -1,9 +1,8 @@
 import datetime
-import urllib.parse
 
 import freezegun
-import jwt
 import pytest
+
 from supernote.server.utils.url_signer import UrlSigner
 
 
@@ -17,7 +16,7 @@ def test_sign_and_verify(signer: UrlSigner) -> None:
     """Test that signing and verification work."""
     path = "/test/path"
     signed_url = signer.sign(path)
-    
+
     # Verify using full URL
     assert signer.verify(signed_url) is True
 
@@ -33,10 +32,10 @@ def test_verify_failure_tampered_url(signer: UrlSigner) -> None:
     """Test that verification fails for tampered URLs."""
     path = "/original"
     signed_url = signer.sign(path)
-    
+
     # Tamper with the path part of the URL (e.g. user changes /original to /hacked)
     tampered_url = signed_url.replace("/original", "/hacked")
-    
+
     assert signer.verify(tampered_url) is False
 
 
@@ -51,10 +50,10 @@ def test_verify_failure_expired(signer: UrlSigner) -> None:
     with freezegun.freeze_time(initial_time) as frozen_time:
         path = "/expired"
         signed_url = signer.sign(path, expiration=datetime.timedelta(minutes=7))
-        
+
         # Advance time past expiry
         frozen_time.tick(delta=datetime.timedelta(minutes=8))
-        
+
         assert signer.verify(signed_url) is False
 
 
@@ -68,7 +67,7 @@ def test_sign_preserves_query_check(signer: UrlSigner) -> None:
     """Test that signing respects existing query params."""
     path = "/api/resource?foo=bar"
     signed_url = signer.sign(path)
-    
+
     assert "foo=bar" in signed_url
     assert "signature=" in signed_url
     assert signer.verify(signed_url) is True


### PR DESCRIPTION
Use the API for signing paths inside of the routes.

This moves the tests away from interacting directly with the upload/download endpoints (since they now break, which is the point of this) and now use the client library.