### PR TITLE
fix: update existing file entry in VFS instead of creating duplicates on upload

### DIFF
--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -367,7 +367,7 @@ class FileService:
             if clean_path:
                 parent_id = await vfs.ensure_directory_path(user_id, clean_path)
 
-            new_file = await vfs.create_file(
+            new_file = await vfs.create_or_update_file(
                 user_id=user_id,
                 parent_id=parent_id,
                 name=filename,
@@ -422,7 +422,7 @@ class FileService:
         async with self.session_manager.session() as session:
             vfs = VirtualFileSystem(session)
 
-            new_file = await vfs.create_file(
+            new_file = await vfs.create_or_update_file(
                 user_id=user_id,
                 parent_id=directory_id,
                 name=file_name,

--- a/supernote/server/services/vfs.py
+++ b/supernote/server/services/vfs.py
@@ -87,7 +87,7 @@ class VirtualFileSystem:
 
         return results
 
-    async def create_file(
+    async def create_or_update_file(
         self,
         user_id: int,
         parent_id: int,
@@ -96,10 +96,29 @@ class VirtualFileSystem:
         md5: str,
         storage_key: str,
     ) -> UserFileDO:
-        """Create a file entry (assuming content is handled elsewhere/CAS)."""
+        """Create or update a file entry (assuming content is handled elsewhere/CAS)."""
         now_ms = int(time.time() * 1000)
 
-        # Check quota (TODO: Implement Capacity check)
+        # Check if active file already exists in this folder
+        stmt = select(UserFileDO).where(
+            UserFileDO.user_id == user_id,
+            UserFileDO.directory_id == parent_id,
+            UserFileDO.file_name == name,
+            UserFileDO.is_active == "Y",
+            UserFileDO.is_folder == "N",
+        )
+        result = await self.db.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            # Overwrite/update the existing active file entry
+            existing.size = size
+            existing.md5 = md5
+            existing.storage_key = storage_key
+            existing.update_time = now_ms
+            await self.db.commit()
+            await self.db.refresh(existing)
+            return existing
 
         new_file = UserFileDO(
             user_id=user_id,

--- a/tests/server/services/test_vfs.py
+++ b/tests/server/services/test_vfs.py
@@ -34,7 +34,7 @@ async def test_vfs_file_operations(db_session: AsyncSession) -> None:
     user_id = 888
 
     # Create File
-    file_node = await vfs.create_file(
+    file_node = await vfs.create_or_update_file(
         user_id, 0, "test.txt", size=100, md5="hash", storage_key="test-key"
     )
     assert file_node.file_name == "test.txt"


### PR DESCRIPTION
Resolves the issue where device synchronization results in duplicate conflict files.

### Root Cause
Previously, `create_file` inside `VirtualFileSystem` was unconditionally inserting a new row into the `f_user_file` table on every upload. This caused a new file ID to be generated every time a file was uploaded or modified. The device sync client (`com.ratta.supernote.serverlink`) did not recognize the new ID, treated it as a new remote file, hit a local collision, and saved it under a conflict name (`_CONFLICT_`). Furthermore, this duplication led to multiple active rows for the same file in the database, causing path queries (`query/by/path_v3`) to fail with a `500 Internal Server Error (Multiple results found)`.

### Solution
1. Renamed `create_file` to `create_or_update_file` in VFS.
2. Modified the method to check if an active file with the same name and directory already exists.
3. If it exists, it updates the existing entry (`size`, `md5`, `storage_key`, `update_time`) in-place instead of inserting a duplicate row, preserving the file ID.
4. Updated all callers (device sync and web uploads) and unit tests.
5. All 321 tests pass and linters check out.