### PR TITLE
Optimize Ratta RLE decompression and PNG conversion performance

### DIFF
--- a/supernote/notebook/decoder.py
+++ b/supernote/notebook/decoder.py
@@ -16,7 +16,6 @@
 
 import base64
 import json
-import queue
 import zlib
 
 import numpy as np
@@ -162,6 +161,9 @@ class RattaRleDecoder(BaseDecoder):
 
         colormap = self._create_colormap(palette)
 
+        # Precompute color byte arrays of size 256 for fast lookup
+        color_bytes_list = self._precompute_color_bytes(palette, colormap)
+
         if horizontal:
             page_height, page_width = (page_width, page_height)  # swap width and height
 
@@ -171,7 +173,6 @@ class RattaRleDecoder(BaseDecoder):
         bin = iter(data)
         try:
             holder = ()
-            waiting = queue.Queue()
             while True:
                 colorcode = next(bin)
                 length = next(bin)
@@ -182,11 +183,11 @@ class RattaRleDecoder(BaseDecoder):
                     holder = ()
                     if colorcode == prev_colorcode:
                         length = 1 + length + (((prev_length & 0x7F) + 1) << 7)
-                        waiting.put((colorcode, length))
+                        uncompressed += color_bytes_list[colorcode] * length
                         data_pushed = True
                     else:
                         prev_length = ((prev_length & 0x7F) + 1) << 7
-                        waiting.put((prev_colorcode, prev_length))
+                        uncompressed += color_bytes_list[prev_colorcode] * prev_length
 
                 if not data_pushed:
                     if length == self.SPECIAL_LENGTH_MARKER:
@@ -194,21 +195,13 @@ class RattaRleDecoder(BaseDecoder):
                             length = self.SPECIAL_LENGTH_FOR_BLANK
                         else:
                             length = self.SPECIAL_LENGTH
-                        waiting.put((colorcode, length))
-                        data_pushed = True
+                        uncompressed += color_bytes_list[colorcode] * length
                     elif length & 0x80 != 0:
                         holder = (colorcode, length)
                         # holded data are processed at next loop
                     else:
                         length += 1
-                        waiting.put((colorcode, length))
-                        data_pushed = True
-
-                while not waiting.empty():
-                    (colorcode, length) = waiting.get()
-                    uncompressed += self._create_color_bytearray(
-                        palette.mode, colormap, colorcode, length
-                    )
+                        uncompressed += color_bytes_list[colorcode] * length
         except StopIteration:
             if len(holder) > 0:
                 (colorcode, length) = holder
@@ -216,9 +209,7 @@ class RattaRleDecoder(BaseDecoder):
                     length, len(uncompressed), expected_length
                 )
                 if length > 0:
-                    uncompressed += self._create_color_bytearray(
-                        palette.mode, colormap, colorcode, length
-                    )
+                    uncompressed += color_bytes_list[colorcode] * length
 
         if len(uncompressed) != expected_length:
             raise exceptions.DecoderException(
@@ -240,23 +231,42 @@ class RattaRleDecoder(BaseDecoder):
         }
         return colormap
 
-    def _create_color_bytearray(self, mode, colormap, color_code, length):
-        if mode == color.MODE_RGB:
-            c = colormap.get(color_code)
-            r, g, b = color.get_rgb(c)
-            return (
-                bytearray(
-                    (
-                        r,
-                        g,
-                        b,
-                    )
-                )
-                * length
-            )
-        else:
-            c = colormap.get(color_code)
-            return bytearray((c,)) * length
+    def _precompute_color_bytes(
+        self, palette: color.ColorPalette, colormap: dict[int, int]
+    ) -> list[bytes]:
+        """Precomputes color byte sequences for all 256 possible RLE color codes.
+
+        This list maps Ratta RLE compressed color codes (indices 0 to 255) directly
+        to their decompressed byte representations (either 1-byte grayscale values or
+        3-byte RGB values) to avoid repeated dictionary lookups, conditional checks,
+        and tuple/byte conversions during decompression.
+
+        Parameters
+        ----------
+        palette : color.ColorPalette
+            The active color palette indicating the color mode (grayscale or RGB).
+        colormap : dict[int, int]
+            A dictionary mapping Ratta RLE color codes to their corresponding palette values.
+
+        Returns
+        -------
+        list[bytes]
+            A list of 256 bytes objects where the index is the RLE color code.
+        """
+        color_bytes_list = [b""] * 256
+        for code in range(256):
+            c = colormap.get(code)
+            if palette.mode == color.MODE_RGB:
+                if c is not None:
+                    r, g, b = color.get_rgb(c)
+                else:
+                    r, g, b = (code, code, code)
+                color_bytes_list[code] = bytes((r, g, b))
+            else:
+                if c is None:
+                    c = code
+                color_bytes_list[code] = bytes((c,))
+        return color_bytes_list
 
     def _adjust_tail_length(self, tail_length, current_length, total_length):
         gap = total_length - current_length
@@ -293,29 +303,6 @@ class RattaRleX2Decoder(RattaRleDecoder):
             self.COLORCODE_GRAY_COMPAT: palette.gray_compat,
         }
         return colormap
-
-    def _create_color_bytearray(self, mode, colormap, color_code, length):
-        if mode == color.MODE_RGB:
-            c = colormap.get(color_code)
-            if c is not None:
-                r, g, b = color.get_rgb(c)
-            else:  # if the color_code is not included in colormap, use the value as color directly
-                r, g, b = (color_code, color_code, color_code)
-            return (
-                bytearray(
-                    (
-                        r,
-                        g,
-                        b,
-                    )
-                )
-                * length
-            )
-        else:
-            c = colormap.get(color_code)
-            if c is None:
-                c = color_code
-            return bytearray((c,)) * length
 
 
 class PngDecoder(BaseDecoder):


### PR DESCRIPTION
## Summary

This PR optimizes the performance of notebook to PNG conversion by refactoring the `RattaRleDecoder` decompression algorithm in `supernote/notebook/decoder.py`.

### The Problem
During local profiling of a 76MB `Daily.note` file containing 76 pages:
- Converting the note to PNGs took **58.97 seconds** (~0.77s per page).
- **88.8%** of the total runtime was spent in `RattaRleDecoder.decode` (52.38s).
- Inside the decoder, Python's `queue.Queue` was used as a local FIFO buffer in a hot loop. Since `queue.Queue` is thread-safe, it uses internal locks and condition variables. Undergoing **3.3M queue push/pops** and **6.7M queue checks** per page resulted in massive synchronization and lock contention overhead.

### The Solution
1. **Removed `queue.Queue`**: Since the decoder runs sequentially in a single thread, intermediate RLE bytes can be directly written to the output `bytearray` buffer, completely eliminating thread-synchronization overhead.
2. **Precomputed Colormap Byte Arrays**: Extracted a helper method `_precompute_color_bytes` to precompute all 256 possible RLE color code mappings into a list of pre-allocated `bytes` (1-byte grayscale or 3-byte RGB) at the start of decompression. This avoids 3.3 million dictionary lookups and byte/tuple conversions during hot loops.
3. **Dead Code Cleanup**: Removed the unused `_create_color_bytearray` method from both `RattaRleDecoder` and `RattaRleX2Decoder`.

---

## Performance & Benchmark Data
We compared the PNG conversion speed of all 76 pages of the 76MB `Daily.note` file before and after the optimizations:

| Metric | Before | After | Speedup |
| :--- | :--- | :--- | :--- |
| **Total PNG Conversion Time** | **58.97s** | **9.15s** | **6.45x faster** |
| **Decoder Decompression Time** | **52.38s** | **3.43s** | **15.2x faster** |
| **Color Array Precomputation** | (N/A) | **1.81s saved** | **40% speedup** on core decoding |
| **Total Stack Function Calls** | **123.7M** | **10.6M** | **91.4% fewer calls** |

### Profile (Before)
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      152    8.420    0.055   52.381    0.345 decoder.py:126(decode)
  3303494    5.442    0.000   15.043    0.000 queue.py:177(get)          <-- Lock contention
  3303494    4.643    0.000   13.060    0.000 queue.py:137(put)          <-- Lock contention
  6781899    5.609    0.000   11.162    0.000 queue.py:112(empty)        <-- Lock contention
```

### Profile (After)
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      152    2.306    0.015    3.433    0.023 decoder.py:126(decode)     <-- Optimized!
```

---

## Verification
- **Unit Tests**: Ran `./script/test` and verified that all 321 unit tests pass successfully.
- **Linters**: Ran `./script/lint` and verified formatting, typing, and spelling linters pass cleanly.
