### PR TITLE
feat: add admin CLI background queue controls

### DIFF
--- a/supernote/cli/admin.py
+++ b/supernote/cli/admin.py
@@ -51,9 +51,9 @@ async def add_user_async(
             sys.exit(1)
 
 
-async def list_users_async():
+async def list_users_async(url: str | None = None):
     """Async implementation of list users."""
-    async with create_session() as session:
+    async with create_session(url) as session:
         client = session.client
         try:
             users = await client.get_json("/api/admin/users", list)
@@ -98,7 +98,7 @@ def add_user(args):
 
 
 def list_users(args):
-    asyncio.run(list_users_async())
+    asyncio.run(list_users_async(args.url))
 
 
 async def reset_password_async(url: str, email: str, password: str):
@@ -127,6 +127,64 @@ def reset_password(args):
             sys.exit(1)
 
     asyncio.run(reset_password_async(args.url, args.email, password))
+
+
+async def queue_status_async(url: str | None = None):
+    """Show the background processing queue status."""
+    async with create_session(url) as session:
+        admin_client = AdminClient(session.client)
+        try:
+            status = await admin_client.get_queue_status()
+            print()
+            print("Queue Processing Status")
+            print("=======================")
+            print(f"Status:            {'PAUSED' if status.paused else 'RUNNING'}")
+            print(f"Queue Size:        {status.queue_size}")
+            print(
+                f"Processing Files:  {', '.join(map(str, status.processing_files)) if status.processing_files else 'None'}"
+            )
+            print()
+        except Exception as e:
+            print(f"Failed to get queue status: {e}")
+            sys.exit(1)
+
+
+async def queue_stop_async(url: str | None = None):
+    """Stop/pause the background processing queue."""
+    async with create_session(url) as session:
+        admin_client = AdminClient(session.client)
+        try:
+            print("Attempting to stop/pause background queue processing...")
+            await admin_client.stop_queue()
+            print("Success: Queue processing stopped.")
+        except Exception as e:
+            print(f"Failed to stop queue: {e}")
+            sys.exit(1)
+
+
+async def queue_start_async(url: str | None = None):
+    """Start/resume the background processing queue."""
+    async with create_session(url) as session:
+        admin_client = AdminClient(session.client)
+        try:
+            print("Attempting to start/resume background queue processing...")
+            await admin_client.start_queue()
+            print("Success: Queue processing started.")
+        except Exception as e:
+            print(f"Failed to start queue: {e}")
+            sys.exit(1)
+
+
+def queue_status(args):
+    asyncio.run(queue_status_async(args.url))
+
+
+def queue_stop(args):
+    asyncio.run(queue_stop_async(args.url))
+
+
+def queue_start(args):
+    asyncio.run(queue_start_async(args.url))
 
 
 def add_parser(subparsers):
@@ -176,3 +234,30 @@ def add_parser(subparsers):
         "--password", type=str, help="New password (if omitted, prompt interactively)"
     )
     parser_user_reset.set_defaults(func=reset_password)
+
+    # --- Queue Management ---
+    parser_queue = admin_subparsers.add_parser(
+        "queue", help="Queue management commands"
+    )
+    queue_subparsers = parser_queue.add_subparsers(dest="queue_command")
+
+    # queue status
+    parser_queue_status = queue_subparsers.add_parser(
+        "status",
+        help="Show queue processing status",
+    )
+    parser_queue_status.set_defaults(func=queue_status)
+
+    # queue stop
+    parser_queue_stop = queue_subparsers.add_parser(
+        "stop",
+        help="Stop/pause the queue processing",
+    )
+    parser_queue_stop.set_defaults(func=queue_stop)
+
+    # queue start
+    parser_queue_start = queue_subparsers.add_parser(
+        "start",
+        help="Start/resume the queue processing",
+    )
+    parser_queue_start.set_defaults(func=queue_start)

--- a/supernote/client/admin.py
+++ b/supernote/client/admin.py
@@ -2,6 +2,7 @@ import logging
 
 from supernote.client.client import Client
 from supernote.models.base import BaseResponse
+from supernote.models.system import QueueStatusVO
 from supernote.models.user import (
     RetrievePasswordDTO,
     UpdateEmailDTO,
@@ -74,3 +75,19 @@ class AdminClient:
             json={"email": email, "password": password_md5},
         )
         logger.info(f"Password reset for {email}")
+
+    async def stop_queue(self) -> None:
+        """Stop/pause the queue processing."""
+        await self.client.post_json("/api/admin/queue/stop", BaseResponse)
+        logger.info("Stopped/paused background queue processing")
+
+    async def start_queue(self) -> None:
+        """Start/resume the queue processing."""
+        await self.client.post_json("/api/admin/queue/start", BaseResponse)
+        logger.info("Started/resumed background queue processing")
+
+    async def get_queue_status(self) -> QueueStatusVO:
+        """Get the background queue processing status."""
+        from supernote.models.system import QueueStatusVO
+
+        return await self.client.get_json("/api/admin/queue/status", QueueStatusVO)

--- a/supernote/models/system.py
+++ b/supernote/models/system.py
@@ -429,3 +429,23 @@ class ReferenceRespVO(BaseResponse):
         metadata=field_options(alias="paramList"), default_factory=list
     )
     random: str | None = None
+
+
+@dataclass(kw_only=True)
+class QueueStatusVO(BaseResponse):
+    """Queue processing status response.
+
+    Used by:
+        /api/admin/queue/status (GET)
+    """
+
+    paused: bool = False
+    """Whether processing is paused."""
+
+    queue_size: int = field(metadata=field_options(alias="queueSize"), default=0)
+    """Number of items in the queue."""
+
+    processing_files: list[int] = field(
+        metadata=field_options(alias="processingFiles"), default_factory=list
+    )
+    """List of file IDs currently being processed."""

--- a/supernote/server/app.py
+++ b/supernote/server/app.py
@@ -309,7 +309,7 @@ def create_app(config: ServerConfig) -> web.Application:
     app["rate_limiter"] = RateLimiter(coordination_service)
 
     processor_service = ProcessorService(
-        event_bus, session_manager, file_service, summary_service
+        event_bus, session_manager, file_service, summary_service, coordination_service
     )
     app["processor_service"] = processor_service
 

--- a/supernote/server/routes/admin.py
+++ b/supernote/server/routes/admin.py
@@ -107,3 +107,36 @@ async def handle_list_users(request: web.Request) -> web.Response:
 
     # Simple list response for now
     return web.json_response([vo.to_dict() for vo in user_vos])
+
+
+@routes.post("/api/admin/queue/stop")
+@require_admin
+async def handle_stop_queue(request: web.Request) -> web.Response:
+    """Stop/pause the queue processing."""
+    processor_service = request.app["processor_service"]
+    await processor_service.pause()
+    return web.json_response(BaseResponse().to_dict())
+
+
+@routes.post("/api/admin/queue/start")
+@require_admin
+async def handle_start_queue(request: web.Request) -> web.Response:
+    """Start/resume the queue processing."""
+    processor_service = request.app["processor_service"]
+    await processor_service.resume()
+    return web.json_response(BaseResponse().to_dict())
+
+
+@routes.get("/api/admin/queue/status")
+@require_admin
+async def handle_queue_status(request: web.Request) -> web.Response:
+    """Get the queue status."""
+    processor_service = request.app["processor_service"]
+    from supernote.models.system import QueueStatusVO
+
+    status = QueueStatusVO(
+        paused=not processor_service.is_processing_enabled(),
+        queue_size=processor_service.queue.qsize(),
+        processing_files=list(processor_service.processing_files),
+    )
+    return web.json_response(status.to_dict())

--- a/supernote/server/services/processor.py
+++ b/supernote/server/services/processor.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import time
-from typing import List, Set
+from typing import Any, List, Set
 
 from sqlalchemy import delete, select
 
@@ -36,12 +36,14 @@ class ProcessorService:
         session_manager: DatabaseSessionManager,
         file_service: FileService,
         summary_service: SummaryService,
+        coordination_service: Any = None,
         concurrency: int = 2,
     ) -> None:
         self.event_bus = event_bus
         self.session_manager = session_manager
         self.file_service = file_service
         self.summary_service = summary_service
+        self.coordination_service = coordination_service
         self.concurrency = concurrency
 
         self.queue: asyncio.Queue[int] = asyncio.Queue()  # Queue of file_ids
@@ -49,6 +51,8 @@ class ProcessorService:
         self.workers: list[asyncio.Task] = []
         self.polling_task: asyncio.Task | None = None
         self._shutdown_event = asyncio.Event()
+        self._processing_enabled = asyncio.Event()
+        self._processing_enabled.set()
 
         # Module registry
         self.global_pre_modules: List[ProcessorModule] = []
@@ -73,6 +77,23 @@ class ProcessorService:
         """Start the processor service workers and subscriptions."""
         logger.info("Starting ProcessorService...")
 
+        # Load paused state from coordination service if available
+        if self.coordination_service:
+            try:
+                paused_val = await self.coordination_service.get_value("queue_paused")
+                if paused_val == "true":
+                    self._processing_enabled.clear()
+                    logger.info(
+                        "ProcessorService queue processing starts in PAUSED state."
+                    )
+                else:
+                    self._processing_enabled.set()
+            except Exception as e:
+                logger.error(f"Failed to load queue paused state: {e}")
+                self._processing_enabled.set()
+        else:
+            self._processing_enabled.set()
+
         # subscribe to events
         self.event_bus.subscribe(NoteUpdatedEvent, self.handle_note_updated)
         self.event_bus.subscribe(NoteDeletedEvent, self.handle_note_deleted)
@@ -89,6 +110,34 @@ class ProcessorService:
 
         # Start Polling Loop
         self.polling_task = asyncio.create_task(self.poll_loop())
+
+    async def pause(self) -> None:
+        """Pause processing of tasks."""
+        self._processing_enabled.clear()
+        if self.coordination_service:
+            try:
+                await self.coordination_service.set_value("queue_paused", "true")
+            except Exception as e:
+                logger.error(f"Failed to persist queue paused state: {e}")
+        logger.info("ProcessorService queue processing paused.")
+
+    async def resume(self) -> None:
+        """Resume processing of tasks."""
+        self._processing_enabled.set()
+        if self.coordination_service:
+            try:
+                await self.coordination_service.set_value("queue_paused", "false")
+            except Exception as e:
+                logger.error(f"Failed to persist queue resumed state: {e}")
+        logger.info("ProcessorService queue processing resumed.")
+
+        # Trigger immediate recovery scan on resume to pick up any pending work immediately
+        asyncio.create_task(self.recover_tasks())
+        asyncio.create_task(self.recover_missing_tasks())
+
+    def is_processing_enabled(self) -> bool:
+        """Check if queue processing is enabled."""
+        return self._processing_enabled.is_set()
 
     async def stop(self) -> None:
         """Stop the processor service."""
@@ -183,8 +232,9 @@ class ProcessorService:
                 # Wait for 5 minutes (adjustable)
                 # We wait first to avoid thundering herd on startup (recover_tasks handles that)
                 await asyncio.sleep(300)
-                await self.recover_stalled_tasks()
-                await self.recover_missing_tasks()
+                if self.is_processing_enabled():
+                    await self.recover_stalled_tasks()
+                    await self.recover_missing_tasks()
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -250,7 +300,18 @@ class ProcessorService:
         logger.debug(f"Worker {worker_id} started.")
         while not self._shutdown_event.is_set():
             try:
+                # Wait until processing is enabled
+                await self._processing_enabled.wait()
+
                 file_id = await self.queue.get()
+
+                # Re-check processing enabled status in case it was paused while we were waiting on get()
+                if not self.is_processing_enabled():
+                    await self.queue.put(file_id)
+                    self.queue.task_done()
+                    await asyncio.sleep(0.5)
+                    continue
+
                 try:
                     await self.process_file(file_id)
                 except Exception as e:

--- a/tests/server/services/test_processor.py
+++ b/tests/server/services/test_processor.py
@@ -454,3 +454,68 @@ async def test_gemini_concurrency_limit() -> None:
             f"Expected max 2 concurrent calls, saw {max_active_seen}"
         )
         assert active_calls == 0
+
+
+async def test_processor_pause_resume(
+    session_manager: DatabaseSessionManager,
+    mock_file_service: MagicMock,
+) -> None:
+    from supernote.server.services.coordination import SqliteCoordinationService
+
+    coordination_service = SqliteCoordinationService(session_manager)
+
+    processor_service = ProcessorService(
+        event_bus=LocalEventBus(),
+        session_manager=session_manager,
+        file_service=mock_file_service,
+        summary_service=MagicMock(),
+        coordination_service=coordination_service,
+        concurrency=1,
+    )
+
+    # 1. Default state
+    assert processor_service.is_processing_enabled() is True
+
+    # 2. Pause
+    await processor_service.pause()
+    assert processor_service.is_processing_enabled() is False
+    assert await coordination_service.get_value("queue_paused") == "true"
+
+    # Start service in paused state
+    processor_service.register_modules(
+        hashing=MagicMock(),
+        png=MagicMock(),
+        ocr=MagicMock(),
+        embedding=MagicMock(),
+        summary=MagicMock(),
+    )
+
+    with patch(
+        "supernote.server.services.processor.ProcessorService.process_file",
+        new_callable=AsyncMock,
+    ) as mock_process:
+        # Start the workers (they will be blocked since it's paused)
+        for i in range(processor_service.concurrency):
+            worker = asyncio.create_task(processor_service.worker_loop(i))
+            processor_service.workers.append(worker)
+
+        # Enqueue file ID
+        await processor_service.queue.put(101)
+        await asyncio.sleep(0.1)
+
+        # process_file should NOT have been called
+        mock_process.assert_not_called()
+
+        # 3. Resume
+        await processor_service.resume()
+        assert processor_service.is_processing_enabled() is True
+        assert await coordination_service.get_value("queue_paused") == "false"
+
+        # Wait for the worker to process the item
+        await asyncio.sleep(0.1)
+
+        # process_file should now have been called
+        mock_process.assert_called_once_with(101)
+
+        # Cleanup
+        await processor_service.stop()

--- a/tests/server/test_admin_api.py
+++ b/tests/server/test_admin_api.py
@@ -177,3 +177,57 @@ async def test_admin_force_password_reset(
         user = result.scalar_one_or_none()
         assert user is not None
         assert user.password_md5 == new_pw
+
+
+async def test_admin_queue_control(
+    client: Client,
+    session_manager: DatabaseSessionManager,
+    coordination_service: CoordinationService,
+    server_config: ServerConfig,
+    admin_headers: dict[str, str],
+    user_headers: dict[str, str],
+) -> None:
+    """Test stopping, starting, and getting queue status."""
+    await setup_users(session_manager, coordination_service, server_config)
+
+    # 1. Access control tests
+    # Non-admin status get should fail
+    resp = await client.get("/api/admin/queue/status", headers=user_headers)
+    assert resp.status == 403
+
+    # Non-admin stop should fail
+    resp = await client.post("/api/admin/queue/stop", headers=user_headers)
+    assert resp.status == 403
+
+    # Non-admin start should fail
+    resp = await client.post("/api/admin/queue/start", headers=user_headers)
+    assert resp.status == 403
+
+    # 2. Admin functionality tests
+    # Admin status should succeed, default should be running (paused=False)
+    resp = await client.get("/api/admin/queue/status", headers=admin_headers)
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["paused"] is False
+    assert data["queueSize"] == 0
+    assert data["processingFiles"] == []
+
+    # Stop queue
+    resp = await client.post("/api/admin/queue/stop", headers=admin_headers)
+    assert resp.status == 200
+
+    # Status should now show paused
+    resp = await client.get("/api/admin/queue/status", headers=admin_headers)
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["paused"] is True
+
+    # Start queue
+    resp = await client.post("/api/admin/queue/start", headers=admin_headers)
+    assert resp.status == 200
+
+    # Status should show running again
+    resp = await client.get("/api/admin/queue/status", headers=admin_headers)
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["paused"] is False


### PR DESCRIPTION
Adds administration REST endpoints and CLI commands to start, stop (pause), and query status of the background note-processing queue. Also includes integration and unit tests verifying the behaviors.