### PR TITLE
fix: resolve sqlite concurrency locks and thundering herd failures

### DIFF
--- a/supernote/server/constants.py
+++ b/supernote/server/constants.py
@@ -24,3 +24,13 @@ CACHE_BUCKET = "supernote-cache"
 
 # Maximum upload size for file uploads
 MAX_UPLOAD_SIZE = 1024 * 1024 * 1024  # 1GB
+
+# Database connection settings
+SQLITE_TIMEOUT_SECONDS = 60.0
+
+# Task processing queue settings
+DEFAULT_PAGE_CONCURRENCY = 4
+
+# Task status database write retry settings
+DB_WRITE_MAX_RETRIES = 5
+DB_WRITE_RETRY_BACKOFF_SECONDS = 0.1

--- a/supernote/server/db/session.py
+++ b/supernote/server/db/session.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from supernote.server.constants import SQLITE_TIMEOUT_SECONDS
 from supernote.server.exceptions import DatabaseError, SupernoteError
 from supernote.server.metrics import DB_SESSION_ERRORS_TOTAL, DB_SESSIONS_ACTIVE
 
@@ -52,7 +53,7 @@ class DatabaseSessionManager:
         if "sqlite" in host:
             connect_args = engine_kwargs.setdefault("connect_args", {})
             if "timeout" not in connect_args:
-                connect_args["timeout"] = 60.0
+                connect_args["timeout"] = SQLITE_TIMEOUT_SECONDS
 
         self._engine: AsyncEngine | None = create_async_engine(host, **engine_kwargs)
         self._sessionmaker: async_sessionmaker | None = async_sessionmaker(

--- a/supernote/server/db/session.py
+++ b/supernote/server/db/session.py
@@ -18,6 +18,7 @@ session_manager.close()
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 
+from sqlalchemy import event
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -43,11 +44,30 @@ class DatabaseSessionManager:
     def __init__(self, host: str, engine_kwargs: dict[str, Any] | None = None):
         """Initialize the database session manager."""
         if engine_kwargs is None:
-            engine_kwargs = ENGINE_KWARGS
+            engine_kwargs = dict(ENGINE_KWARGS)
+        else:
+            engine_kwargs = dict(engine_kwargs)
+
+        # Apply SQLite timeout connection parameter
+        if "sqlite" in host:
+            connect_args = engine_kwargs.setdefault("connect_args", {})
+            if "timeout" not in connect_args:
+                connect_args["timeout"] = 60.0
+
         self._engine: AsyncEngine | None = create_async_engine(host, **engine_kwargs)
         self._sessionmaker: async_sessionmaker | None = async_sessionmaker(
             autocommit=False, bind=self._engine, expire_on_commit=False
         )
+
+        # Enable WAL (Write-Ahead Logging) and Normal synchronous mode for SQLite
+        if "sqlite" in host:
+
+            @event.listens_for(self._engine.sync_engine, "connect")
+            def set_sqlite_pragma(dbapi_connection, connection_record):
+                cursor = dbapi_connection.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA synchronous=NORMAL")
+                cursor.close()
 
     async def close(self) -> None:
         """Close the database session manager."""

--- a/supernote/server/services/processor.py
+++ b/supernote/server/services/processor.py
@@ -44,6 +44,7 @@ class ProcessorService:
         summary_service: SummaryService,
         coordination_service: Any = None,
         concurrency: int = 2,
+        page_concurrency: int = 4,
     ) -> None:
         self.event_bus = event_bus
         self.session_manager = session_manager
@@ -51,6 +52,7 @@ class ProcessorService:
         self.summary_service = summary_service
         self.coordination_service = coordination_service
         self.concurrency = concurrency
+        self.page_concurrency = page_concurrency
 
         self.queue: asyncio.Queue[int] = asyncio.Queue()  # Queue of file_ids
         self.processing_files: Set[int] = set()
@@ -376,9 +378,15 @@ class ProcessorService:
         if not pages:
             logger.info(f"No pages found for file {file_id}. Skipping page tasks.")
         else:
-            # Pipeline Stage: Per-Page Processing (Parallel across pages)
+            # Pipeline Stage: Per-Page Processing (Parallel across pages with limit)
+            sem = asyncio.Semaphore(self.page_concurrency)
+
+            async def throttled_process_page(page_index: int, page_id: str):
+                async with sem:
+                    await self._process_page(file_id, page_index, page_id)
+
             tasks = [
-                self._process_page(file_id, page_index, page_id)
+                throttled_process_page(page_index, page_id)
                 for page_index, page_id in pages
                 if page_id  # Strict Check: Everything must have a page_id
             ]
@@ -390,19 +398,25 @@ class ProcessorService:
 
     async def _process_page(self, file_id: int, page_index: int, page_id: str) -> None:
         """Process all modules for a single page sequentially."""
-        for module in self.page_modules:
-            # We enforce page_id as the task key
-            success = await module.run(
-                file_id,
-                self.session_manager,
-                page_index=page_index,
-                page_id=page_id,  # Pass page_id to modules
-            )
-            if not success:
-                logger.warning(
-                    f"Page {page_id} (idx {page_index}) processing stalled at {module.name} for file {file_id}"
+        try:
+            for module in self.page_modules:
+                # We enforce page_id as the task key
+                success = await module.run(
+                    file_id,
+                    self.session_manager,
+                    page_index=page_index,
+                    page_id=page_id,  # Pass page_id to modules
                 )
-                break
+                if not success:
+                    logger.warning(
+                        f"Page {page_id} (idx {page_index}) processing stalled at {module.name} for file {file_id}"
+                    )
+                    break
+        except Exception as e:
+            logger.error(
+                f"Unhandled error processing page {page_id} (idx {page_index}) for file {file_id}: {e}",
+                exc_info=True,
+            )
 
     async def list_system_tasks(self, limit: int = 100) -> List[SystemTaskDO]:
         """List recent system tasks."""

--- a/supernote/server/services/processor.py
+++ b/supernote/server/services/processor.py
@@ -13,7 +13,7 @@ from supernote.server.metrics import (
     PROCESSOR_STALLED_TASKS_RECOVERED_TOTAL,
 )
 
-from ..constants import CACHE_BUCKET
+from ..constants import CACHE_BUCKET, DEFAULT_PAGE_CONCURRENCY
 from ..db.models.file import UserFileDO
 from ..db.models.note_processing import NotePageContentDO, SystemTaskDO
 from ..db.session import DatabaseSessionManager
@@ -44,7 +44,7 @@ class ProcessorService:
         summary_service: SummaryService,
         coordination_service: Any = None,
         concurrency: int = 2,
-        page_concurrency: int = 4,
+        page_concurrency: int = DEFAULT_PAGE_CONCURRENCY,
     ) -> None:
         self.event_bus = event_bus
         self.session_manager = session_manager

--- a/supernote/server/utils/tasks.py
+++ b/supernote/server/utils/tasks.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import time
 from typing import Optional
 
@@ -7,6 +9,8 @@ from supernote.models.base import ProcessingStatus
 from supernote.server.db.models.note_processing import SystemTaskDO
 from supernote.server.db.session import DatabaseSessionManager
 from supernote.server.utils.unique_id import next_id
+
+logger = logging.getLogger(__name__)
 
 
 async def get_task(
@@ -39,33 +43,48 @@ async def update_task_status(
     status: ProcessingStatus,
     error: Optional[str] = None,
 ) -> None:
-    """Create or update a SystemTaskDO status atomically."""
-    async with session_manager.session() as session:
-        now = int(time.time() * 1000)
-        # Using native SQL UPSERT because SQLite's ON CONFLICT
-        # is very robust for our needs and avoids SELECT-then-UPDATE races.
-        # We must provide 'id' and 'retry_count' manually for the INSERT part.
-        sql = text(
-            """
-            INSERT INTO f_system_task (id, file_id, task_type, key, status, last_error, retry_count, create_time, update_time)
-            VALUES (:id, :file_id, :task_type, :key, :status, :error, 0, :now, :now)
-            ON CONFLICT(file_id, task_type, key) DO UPDATE SET
-                status = excluded.status,
-                last_error = excluded.last_error,
-                update_time = excluded.update_time
-        """
-        )
+    """Create or update a SystemTaskDO status atomically with retries for lock conflicts."""
+    max_retries = 5
+    backoff = 0.1  # seconds
 
-        await session.execute(
-            sql,
-            {
-                "id": next_id(),
-                "file_id": file_id,
-                "task_type": task_type,
-                "key": key,
-                "status": status,
-                "error": error,
-                "now": now,
-            },
-        )
-        await session.commit()
+    for attempt in range(max_retries):
+        try:
+            async with session_manager.session() as session:
+                now = int(time.time() * 1000)
+                # Using native SQL UPSERT because SQLite's ON CONFLICT
+                # is very robust for our needs and avoids SELECT-then-UPDATE races.
+                # We must provide 'id' and 'retry_count' manually for the INSERT part.
+                sql = text(
+                    """
+                    INSERT INTO f_system_task (id, file_id, task_type, key, status, last_error, retry_count, create_time, update_time)
+                    VALUES (:id, :file_id, :task_type, :key, :status, :error, 0, :now, :now)
+                    ON CONFLICT(file_id, task_type, key) DO UPDATE SET
+                        status = excluded.status,
+                        last_error = excluded.last_error,
+                        update_time = excluded.update_time
+                """
+                )
+
+                await session.execute(
+                    sql,
+                    {
+                        "id": next_id(),
+                        "file_id": file_id,
+                        "task_type": task_type,
+                        "key": key,
+                        "status": status,
+                        "error": error,
+                        "now": now,
+                    },
+                )
+                await session.commit()
+                return  # Success!
+        except Exception as e:
+            if "locked" in str(e).lower() and attempt < max_retries - 1:
+                logger.warning(
+                    f"Database locked during task status update for file {file_id} (attempt {attempt + 1}/{max_retries}). Retrying in {backoff}s..."
+                )
+                await asyncio.sleep(backoff)
+                backoff *= 2
+            else:
+                raise

--- a/supernote/server/utils/tasks.py
+++ b/supernote/server/utils/tasks.py
@@ -6,8 +6,13 @@ from typing import Optional
 from sqlalchemy import select, text
 
 from supernote.models.base import ProcessingStatus
+from supernote.server.constants import (
+    DB_WRITE_MAX_RETRIES,
+    DB_WRITE_RETRY_BACKOFF_SECONDS,
+)
 from supernote.server.db.models.note_processing import SystemTaskDO
 from supernote.server.db.session import DatabaseSessionManager
+from supernote.server.exceptions import DatabaseError
 from supernote.server.utils.unique_id import next_id
 
 logger = logging.getLogger(__name__)
@@ -44,8 +49,8 @@ async def update_task_status(
     error: Optional[str] = None,
 ) -> None:
     """Create or update a SystemTaskDO status atomically with retries for lock conflicts."""
-    max_retries = 5
-    backoff = 0.1  # seconds
+    max_retries = DB_WRITE_MAX_RETRIES
+    backoff = DB_WRITE_RETRY_BACKOFF_SECONDS
 
     for attempt in range(max_retries):
         try:
@@ -79,7 +84,7 @@ async def update_task_status(
                 )
                 await session.commit()
                 return  # Success!
-        except Exception as e:
+        except DatabaseError as e:
             if "locked" in str(e).lower() and attempt < max_retries - 1:
                 logger.warning(
                     f"Database locked during task status update for file {file_id} (attempt {attempt + 1}/{max_retries}). Retrying in {backoff}s..."


### PR DESCRIPTION
Resolves SQLite database locking conflicts and per-page task thundering herds during batch notebook processing by adding page-level task throttling (using asyncio.Semaphore), enabling SQLite WAL mode/60s busy timeout, and adding code-level task status write retries with backoff.