### PR TITLE
Optimize note-to-PNG conversion with caching

### DIFF
--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -962,10 +962,11 @@ class FileService:
         file_id: int,
         file_md5: str,
         db_pages: list[tuple[int, str]],
-    ) -> list[ConversionsVO] | None:
-        """Check if all pages exist or can be copied from cache buckets in parallel.
+    ) -> list[ConversionsVO | None] | None:
+        """Check if pages exist or can be copied from cache buckets in parallel.
 
-        Returns the list of ConversionsVO if complete, else None.
+        Returns a list of ConversionsVO | None (where None represents a missing page),
+        or None if db_pages is empty.
         """
         if not db_pages:
             return None
@@ -975,15 +976,7 @@ class FileService:
             for idx, page_id in db_pages
         ]
         results = await asyncio.gather(*tasks)
-
-        cached_results = []
-        for res in results:
-            if res is None:
-                return None
-            cached_results.append(res)
-
-        logger.info(f"Returning cached/copied PNG conversions for file {file_id}")
-        return cached_results
+        return list(results)
 
     async def _convert_note_to_png_fallback(
         self,
@@ -992,6 +985,7 @@ class FileService:
         file_md5: str,
         storage_key: str,
         db_pages: list[tuple[int, str]],
+        cached_results: list[ConversionsVO | None] | None = None,
     ) -> list[ConversionsVO]:
         """Download notebook, parse it, and render/upload any missing pages."""
         blob_content = b"".join(
@@ -1003,24 +997,29 @@ class FileService:
         # Offload heavy CPU-bound note loading to a worker thread
         note = await asyncio.to_thread(_load_notebook_sync, blob_content)
 
-        db_pages_map = {idx: page_id for idx, page_id in db_pages} if db_pages else {}
+        total_pages = note.get_total_pages()
 
-        # 1. Check and copy cached pages in parallel first (non-blocking metadata operations)
-        tasks = [
-            self._process_single_page_cache(
-                user_id=user_id,
-                file_id=file_id,
-                file_md5=file_md5,
-                idx=i,
-                page_id=db_pages_map.get(i),
+        # If we don't have pre-computed cache checks (e.g. db_pages was empty), run them in parallel now
+        if cached_results is None:
+            db_pages_map = (
+                {idx: page_id for idx, page_id in db_pages} if db_pages else {}
             )
-            for i in range(note.get_total_pages())
-        ]
-        results = await asyncio.gather(*tasks)
+            tasks = [
+                self._process_single_page_cache(
+                    user_id=user_id,
+                    file_id=file_id,
+                    file_md5=file_md5,
+                    idx=i,
+                    page_id=db_pages_map.get(i),
+                )
+                for i in range(total_pages)
+            ]
+            cached_results = list(await asyncio.gather(*tasks))
 
-        # 2. Render and upload any pages that are still missing (sequentially to prevent RAM/CPU spikes)
+        # Render and upload any pages that are still missing (sequentially to prevent RAM/CPU spikes)
         final_results = []
-        for i, res in enumerate(results):
+        for i in range(total_pages):
+            res = cached_results[i] if i < len(cached_results) else None
             if res is not None:
                 final_results.append(res)
                 continue
@@ -1063,8 +1062,10 @@ class FileService:
         cached_results = await self._get_cached_conversions(
             user_id, file_id, file_md5, db_pages
         )
-        if cached_results is not None:
-            return cached_results
+
+        if cached_results is not None and all(r is not None for r in cached_results):
+            logger.info(f"Returning cached/copied PNG conversions for file {file_id}")
+            return [r for r in cached_results if r is not None]
 
         # Fallback to downloading and rendering/uploading missing pages
         if node.storage_key is None:
@@ -1076,6 +1077,7 @@ class FileService:
             file_md5=file_md5,
             storage_key=node.storage_key,
             db_pages=db_pages,
+            cached_results=cached_results,
         )
 
     async def convert_note_to_pdf(

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -16,6 +16,7 @@ from supernote.notebook import (
     load as load_notebook,
 )
 from supernote.server.constants import (
+    CACHE_BUCKET,
     CATEGORY_CONTAINERS,
     IMMUTABLE_SYSTEM_DIRECTORIES,
     USER_DATA_BUCKET,
@@ -31,9 +32,11 @@ from supernote.server.exceptions import (
 from supernote.server.utils.paths import (
     get_conversion_pdf_path,
     get_conversion_png_path,
+    get_page_png_path,
 )
 
 from ..db.models.file import RecycleFileDO, UserFileDO
+from ..db.models.note_processing import NotePageContentDO
 from ..db.session import DatabaseSessionManager
 from ..events import LocalEventBus, NoteDeletedEvent, NoteUpdatedEvent
 from .blob import BlobStorage
@@ -906,6 +909,70 @@ class FileService:
 
             return file_entities
 
+    async def _try_copy_from_cache_bucket(
+        self, file_id: int, page_id: str, dst_key: str
+    ) -> bool:
+        """Attempt to copy page PNG from background CACHE_BUCKET to conversions in USER_DATA_BUCKET."""
+        cache_png_key = get_page_png_path(file_id, page_id)
+        if not await self.blob_storage.exists(CACHE_BUCKET, cache_png_key):
+            return False
+        try:
+            await self.blob_storage.put(
+                USER_DATA_BUCKET,
+                dst_key,
+                self.blob_storage.get(CACHE_BUCKET, cache_png_key),
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                f"Failed to copy cached PNG for file {file_id} page {page_id}: {e}"
+            )
+            return False
+
+    async def _get_cached_conversions(
+        self,
+        user_id: int,
+        file_id: int,
+        file_md5: str,
+        db_pages: list[tuple[int, str]],
+    ) -> list[ConversionsVO] | None:
+        """Check if all pages exist or can be copied from cache buckets.
+
+        Returns the list of ConversionsVO if complete, else None.
+        """
+        if not db_pages:
+            return None
+
+        cached_results = []
+        for idx, page_id in db_pages:
+            png_storage_key = get_conversion_png_path(
+                user_id=user_id,
+                file_id=file_id,
+                page_index=idx,
+                file_md5=file_md5,
+            )
+            # 1. Check if already exists in USER_DATA_BUCKET
+            if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
+                cached_results.append(
+                    ConversionsVO(storage_key=png_storage_key, page_no=idx)
+                )
+                continue
+
+            # 2. Check and copy from background CACHE_BUCKET
+            if await self._try_copy_from_cache_bucket(
+                file_id, page_id, png_storage_key
+            ):
+                cached_results.append(
+                    ConversionsVO(storage_key=png_storage_key, page_no=idx)
+                )
+                continue
+
+            # If any page is missing and cannot be copied, cache is incomplete
+            return None
+
+        logger.info(f"Returning cached/copied PNG conversions for file {file_id}")
+        return cached_results
+
     async def convert_note_to_png(self, user: str, file_id: int) -> list[ConversionsVO]:
         """Convert a note to PNG pages."""
         user_id = await self.user_service.get_user_id(user)
@@ -914,39 +981,72 @@ class FileService:
             node = await vfs.get_node_by_id(user_id, file_id)
             if not node or node.is_folder == "Y":
                 raise FileNotFound(f"Note file {file_id} not found")
+            if not node.md5:
+                raise FileError(f"Note file {file_id} is missing MD5 hash")
 
-            # Load notebook from blob storage
-            if node.storage_key is None:
-                raise FileNotFound(f"Note file {file_id} has no content")
-            blob_content = b"".join(
-                [
-                    chunk
-                    async for chunk in self.blob_storage.get(
-                        USER_DATA_BUCKET, node.storage_key
-                    )
-                ]
+            # Get page metadata from database
+            stmt = (
+                select(NotePageContentDO.page_index, NotePageContentDO.page_id)
+                .where(NotePageContentDO.file_id == file_id)
+                .order_by(NotePageContentDO.page_index)
             )
-            # Offload heavy CPU-bound note loading to a worker thread
-            note = await asyncio.to_thread(_load_notebook_sync, blob_content)
+            res = await session.execute(stmt)
+            db_pages = [(row[0], row[1]) for row in res.all()]
 
-            # Convert and upload pages one by one to keep memory footprint minimal
-            results = []
-            for i in range(note.get_total_pages()):
-                img_bytes = await asyncio.to_thread(_convert_single_page_sync, note, i)
-                # Store PNG in blob storage with a unique key
-                # Format: conversions/{user_id}/{file_id}/page_{i}_{md5}.png
-                png_storage_key = get_conversion_png_path(
-                    user_id=user_id,
-                    file_id=file_id,
-                    page_index=i,
-                    file_md5=node.md5 or "nomd5",
+        file_md5 = node.md5
+
+        # Check if we can reuse already converted PNGs from USER_DATA_BUCKET or CACHE_BUCKET
+        cached_results = await self._get_cached_conversions(
+            user_id, file_id, file_md5, db_pages
+        )
+        if cached_results is not None:
+            return cached_results
+
+        # Fallback to downloading and rendering/uploading missing pages
+        if node.storage_key is None:
+            raise FileNotFound(f"Note file {file_id} has no content")
+        blob_content = b"".join(
+            [
+                chunk
+                async for chunk in self.blob_storage.get(
+                    USER_DATA_BUCKET, node.storage_key
                 )
-                await self.blob_storage.put(
-                    USER_DATA_BUCKET, png_storage_key, img_bytes
-                )
+            ]
+        )
+        # Offload heavy CPU-bound note loading to a worker thread
+        note = await asyncio.to_thread(_load_notebook_sync, blob_content)
+
+        # Convert and upload pages one by one to keep memory footprint minimal
+        results = []
+        db_pages_map = {idx: page_id for idx, page_id in db_pages} if db_pages else {}
+
+        for i in range(note.get_total_pages()):
+            png_storage_key = get_conversion_png_path(
+                user_id=user_id,
+                file_id=file_id,
+                page_index=i,
+                file_md5=file_md5,
+            )
+
+            # 1. Check if PNG already exists in USER_DATA_BUCKET
+            if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
                 results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+                continue
 
-            return results
+            # 2. Check if we can copy from CACHE_BUCKET
+            page_id = db_pages_map.get(i)
+            if page_id and await self._try_copy_from_cache_bucket(
+                file_id, page_id, png_storage_key
+            ):
+                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+                continue
+
+            # 3. Fallback: render and upload
+            img_bytes = await asyncio.to_thread(_convert_single_page_sync, note, i)
+            await self.blob_storage.put(USER_DATA_BUCKET, png_storage_key, img_bytes)
+            results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+
+        return results
 
     async def convert_note_to_pdf(
         self, user: str, file_id: int, page_no_list: list[int]
@@ -958,6 +1058,8 @@ class FileService:
             node = await vfs.get_node_by_id(user_id, file_id)
             if not node or node.is_folder == "Y":
                 raise FileNotFound(f"Note file {file_id} not found")
+            if not node.md5:
+                raise FileError(f"Note file {file_id} is missing MD5 hash")
 
             # Load notebook
             if node.storage_key is None:
@@ -978,7 +1080,7 @@ class FileService:
 
             # 3. Store PDF
             pdf_storage_key = get_conversion_pdf_path(
-                user_id=user_id, file_id=file_id, file_md5=node.md5 or "nomd5"
+                user_id=user_id, file_id=file_id, file_md5=node.md5
             )
             await self.blob_storage.put(USER_DATA_BUCKET, pdf_storage_key, pdf_bytes)
 

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -929,6 +929,33 @@ class FileService:
             )
             return False
 
+    async def _process_single_page_cache(
+        self,
+        user_id: int,
+        file_id: int,
+        file_md5: str,
+        idx: int,
+        page_id: str | None = None,
+    ) -> ConversionsVO | None:
+        """Process cache check/copy for a single page."""
+        png_storage_key = get_conversion_png_path(
+            user_id=user_id,
+            file_id=file_id,
+            page_index=idx,
+            file_md5=file_md5,
+        )
+        # 1. Check if already exists in USER_DATA_BUCKET
+        if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
+            return ConversionsVO(storage_key=png_storage_key, page_no=idx)
+
+        # 2. Check and copy from background CACHE_BUCKET
+        if page_id and await self._try_copy_from_cache_bucket(
+            file_id, page_id, png_storage_key
+        ):
+            return ConversionsVO(storage_key=png_storage_key, page_no=idx)
+
+        return None
+
     async def _get_cached_conversions(
         self,
         user_id: int,
@@ -936,39 +963,24 @@ class FileService:
         file_md5: str,
         db_pages: list[tuple[int, str]],
     ) -> list[ConversionsVO] | None:
-        """Check if all pages exist or can be copied from cache buckets.
+        """Check if all pages exist or can be copied from cache buckets in parallel.
 
         Returns the list of ConversionsVO if complete, else None.
         """
         if not db_pages:
             return None
 
+        tasks = [
+            self._process_single_page_cache(user_id, file_id, file_md5, idx, page_id)
+            for idx, page_id in db_pages
+        ]
+        results = await asyncio.gather(*tasks)
+
         cached_results = []
-        for idx, page_id in db_pages:
-            png_storage_key = get_conversion_png_path(
-                user_id=user_id,
-                file_id=file_id,
-                page_index=idx,
-                file_md5=file_md5,
-            )
-            # 1. Check if already exists in USER_DATA_BUCKET
-            if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
-                cached_results.append(
-                    ConversionsVO(storage_key=png_storage_key, page_no=idx)
-                )
-                continue
-
-            # 2. Check and copy from background CACHE_BUCKET
-            if await self._try_copy_from_cache_bucket(
-                file_id, page_id, png_storage_key
-            ):
-                cached_results.append(
-                    ConversionsVO(storage_key=png_storage_key, page_no=idx)
-                )
-                continue
-
-            # If any page is missing and cannot be copied, cache is incomplete
-            return None
+        for res in results:
+            if res is None:
+                return None
+            cached_results.append(res)
 
         logger.info(f"Returning cached/copied PNG conversions for file {file_id}")
         return cached_results
@@ -991,36 +1003,39 @@ class FileService:
         # Offload heavy CPU-bound note loading to a worker thread
         note = await asyncio.to_thread(_load_notebook_sync, blob_content)
 
-        results = []
         db_pages_map = {idx: page_id for idx, page_id in db_pages} if db_pages else {}
 
-        for i in range(note.get_total_pages()):
+        # 1. Check and copy cached pages in parallel first (non-blocking metadata operations)
+        tasks = [
+            self._process_single_page_cache(
+                user_id=user_id,
+                file_id=file_id,
+                file_md5=file_md5,
+                idx=i,
+                page_id=db_pages_map.get(i),
+            )
+            for i in range(note.get_total_pages())
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # 2. Render and upload any pages that are still missing (sequentially to prevent RAM/CPU spikes)
+        final_results = []
+        for i, res in enumerate(results):
+            if res is not None:
+                final_results.append(res)
+                continue
+
             png_storage_key = get_conversion_png_path(
                 user_id=user_id,
                 file_id=file_id,
                 page_index=i,
                 file_md5=file_md5,
             )
-
-            # 1. Check if PNG already exists in USER_DATA_BUCKET
-            if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
-                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
-                continue
-
-            # 2. Check if we can copy from CACHE_BUCKET
-            page_id = db_pages_map.get(i)
-            if page_id and await self._try_copy_from_cache_bucket(
-                file_id, page_id, png_storage_key
-            ):
-                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
-                continue
-
-            # 3. Fallback: render and upload
             img_bytes = await asyncio.to_thread(_convert_single_page_sync, note, i)
             await self.blob_storage.put(USER_DATA_BUCKET, png_storage_key, img_bytes)
-            results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+            final_results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
 
-        return results
+        return final_results
 
     async def convert_note_to_png(self, user: str, file_id: int) -> list[ConversionsVO]:
         """Convert a note to PNG pages."""

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -984,7 +984,6 @@ class FileService:
         file_id: int,
         file_md5: str,
         storage_key: str,
-        db_pages: list[tuple[int, str]],
         cached_results: list[ConversionsVO | None] | None = None,
     ) -> list[ConversionsVO]:
         """Download notebook, parse it, and render/upload any missing pages."""
@@ -1001,16 +1000,13 @@ class FileService:
 
         # If we don't have pre-computed cache checks (e.g. db_pages was empty), run them in parallel now
         if cached_results is None:
-            db_pages_map = (
-                {idx: page_id for idx, page_id in db_pages} if db_pages else {}
-            )
             tasks = [
                 self._process_single_page_cache(
                     user_id=user_id,
                     file_id=file_id,
                     file_md5=file_md5,
                     idx=i,
-                    page_id=db_pages_map.get(i),
+                    page_id=None,
                 )
                 for i in range(total_pages)
             ]
@@ -1076,7 +1072,6 @@ class FileService:
             file_id=file_id,
             file_md5=file_md5,
             storage_key=node.storage_key,
-            db_pages=db_pages,
             cached_results=cached_results,
         )
 

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -998,19 +998,9 @@ class FileService:
 
         total_pages = note.get_total_pages()
 
-        # If we don't have pre-computed cache checks (e.g. db_pages was empty), run them in parallel now
+        # If we don't have pre-computed cache checks (e.g. db_pages was empty), initialize empty results
         if cached_results is None:
-            tasks = [
-                self._process_single_page_cache(
-                    user_id=user_id,
-                    file_id=file_id,
-                    file_md5=file_md5,
-                    idx=i,
-                    page_id=None,
-                )
-                for i in range(total_pages)
-            ]
-            cached_results = list(await asyncio.gather(*tasks))
+            cached_results = [None] * total_pages
 
         # Render and upload any pages that are still missing (sequentially to prevent RAM/CPU spikes)
         final_results = []

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -973,6 +973,55 @@ class FileService:
         logger.info(f"Returning cached/copied PNG conversions for file {file_id}")
         return cached_results
 
+    async def _convert_note_to_png_fallback(
+        self,
+        user_id: int,
+        file_id: int,
+        file_md5: str,
+        storage_key: str,
+        db_pages: list[tuple[int, str]],
+    ) -> list[ConversionsVO]:
+        """Download notebook, parse it, and render/upload any missing pages."""
+        blob_content = b"".join(
+            [
+                chunk
+                async for chunk in self.blob_storage.get(USER_DATA_BUCKET, storage_key)
+            ]
+        )
+        # Offload heavy CPU-bound note loading to a worker thread
+        note = await asyncio.to_thread(_load_notebook_sync, blob_content)
+
+        results = []
+        db_pages_map = {idx: page_id for idx, page_id in db_pages} if db_pages else {}
+
+        for i in range(note.get_total_pages()):
+            png_storage_key = get_conversion_png_path(
+                user_id=user_id,
+                file_id=file_id,
+                page_index=i,
+                file_md5=file_md5,
+            )
+
+            # 1. Check if PNG already exists in USER_DATA_BUCKET
+            if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
+                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+                continue
+
+            # 2. Check if we can copy from CACHE_BUCKET
+            page_id = db_pages_map.get(i)
+            if page_id and await self._try_copy_from_cache_bucket(
+                file_id, page_id, png_storage_key
+            ):
+                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+                continue
+
+            # 3. Fallback: render and upload
+            img_bytes = await asyncio.to_thread(_convert_single_page_sync, note, i)
+            await self.blob_storage.put(USER_DATA_BUCKET, png_storage_key, img_bytes)
+            results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
+
+        return results
+
     async def convert_note_to_png(self, user: str, file_id: int) -> list[ConversionsVO]:
         """Convert a note to PNG pages."""
         user_id = await self.user_service.get_user_id(user)
@@ -1005,48 +1054,14 @@ class FileService:
         # Fallback to downloading and rendering/uploading missing pages
         if node.storage_key is None:
             raise FileNotFound(f"Note file {file_id} has no content")
-        blob_content = b"".join(
-            [
-                chunk
-                async for chunk in self.blob_storage.get(
-                    USER_DATA_BUCKET, node.storage_key
-                )
-            ]
+
+        return await self._convert_note_to_png_fallback(
+            user_id=user_id,
+            file_id=file_id,
+            file_md5=file_md5,
+            storage_key=node.storage_key,
+            db_pages=db_pages,
         )
-        # Offload heavy CPU-bound note loading to a worker thread
-        note = await asyncio.to_thread(_load_notebook_sync, blob_content)
-
-        # Convert and upload pages one by one to keep memory footprint minimal
-        results = []
-        db_pages_map = {idx: page_id for idx, page_id in db_pages} if db_pages else {}
-
-        for i in range(note.get_total_pages()):
-            png_storage_key = get_conversion_png_path(
-                user_id=user_id,
-                file_id=file_id,
-                page_index=i,
-                file_md5=file_md5,
-            )
-
-            # 1. Check if PNG already exists in USER_DATA_BUCKET
-            if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
-                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
-                continue
-
-            # 2. Check if we can copy from CACHE_BUCKET
-            page_id = db_pages_map.get(i)
-            if page_id and await self._try_copy_from_cache_bucket(
-                file_id, page_id, png_storage_key
-            ):
-                results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
-                continue
-
-            # 3. Fallback: render and upload
-            img_bytes = await asyncio.to_thread(_convert_single_page_sync, note, i)
-            await self.blob_storage.put(USER_DATA_BUCKET, png_storage_key, img_bytes)
-            results.append(ConversionsVO(storage_key=png_storage_key, page_no=i))
-
-        return results
 
     async def convert_note_to_pdf(
         self, user: str, file_id: int, page_no_list: list[int]

--- a/supernote/server/services/file.py
+++ b/supernote/server/services/file.py
@@ -923,7 +923,7 @@ class FileService:
                 self.blob_storage.get(CACHE_BUCKET, cache_png_key),
             )
             return True
-        except Exception as e:
+        except OSError as e:
             logger.warning(
                 f"Failed to copy cached PNG for file {file_id} page {page_id}: {e}"
             )
@@ -944,11 +944,11 @@ class FileService:
             page_index=idx,
             file_md5=file_md5,
         )
-        # 1. Check if already exists in USER_DATA_BUCKET
+        # Check if already exists in USER_DATA_BUCKET
         if await self.blob_storage.exists(USER_DATA_BUCKET, png_storage_key):
             return ConversionsVO(storage_key=png_storage_key, page_no=idx)
 
-        # 2. Check and copy from background CACHE_BUCKET
+        # Check and copy from background CACHE_BUCKET
         if page_id and await self._try_copy_from_cache_bucket(
             file_id, page_id, png_storage_key
         ):
@@ -1001,7 +1001,6 @@ class FileService:
         # If we don't have pre-computed cache checks (e.g. db_pages was empty), initialize empty results
         if cached_results is None:
             cached_results = [None] * total_pages
-
         # Render and upload any pages that are still missing (sequentially to prevent RAM/CPU spikes)
         final_results = []
         for i in range(total_pages):

--- a/tests/server/device/test_file_conversion.py
+++ b/tests/server/device/test_file_conversion.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
+from aiohttp.test_utils import TestClient
+from sqlalchemy import delete
+
 from supernote.client.device import DeviceClient
+from supernote.server.constants import CACHE_BUCKET, USER_DATA_BUCKET
+from supernote.server.db.models.note_processing import NotePageContentDO
+from supernote.server.db.session import DatabaseSessionManager
+from supernote.server.utils.paths import get_conversion_png_path, get_page_png_path
 
 
 async def test_note_conversion_wrappers(
@@ -46,3 +53,98 @@ async def test_note_to_pdf_partial(
     # Test PDF with specific page
     pdf_content = await device_client.get_note_pdf(file_id, page_no_list=[0])
     assert pdf_content.startswith(b"%PDF")
+
+
+async def test_note_png_caching(
+    client: TestClient,
+    device_client: DeviceClient,
+    test_note_path: Path,
+    session_manager: DatabaseSessionManager,
+) -> None:
+    # 1. Setup: Upload the test note
+    with test_note_path.open("rb") as f:
+        note_content = f.read()
+
+    filename = "test_caching.note"
+    upload_res = await device_client.upload_content(
+        path=f"/{filename}", content=note_content, equipment_no="SN_TEST"
+    )
+    assert upload_res.id is not None
+    file_id = int(upload_res.id)
+
+    file_service = client.app["file_service"]
+
+    # First conversion: this will download, parse, and save pages to USER_DATA_BUCKET
+    png_pages_first = await device_client.get_note_png_pages(file_id)
+    assert len(png_pages_first) > 0
+
+    # Retrieve file info to get the storage_key
+    user_email = "test@example.com"
+    file_info = await file_service.get_file_info_by_id(user_email, file_id)
+    assert file_info is not None
+    storage_key = file_info.storage_key
+    assert storage_key is not None
+
+    # Deleting the source notebook from USER_DATA_BUCKET to prove caching:
+    # If caching works, it should serve from USER_DATA_BUCKET and NOT attempt to download/parse the source file.
+    await file_service.blob_storage.delete(USER_DATA_BUCKET, storage_key)
+
+    # Second conversion: should succeed because files are cached in USER_DATA_BUCKET
+    # (If caching fails, it will attempt to download the missing source file and throw FileNotFoundError)
+    png_pages_second = await device_client.get_note_png_pages(file_id)
+    assert len(png_pages_second) == len(png_pages_first)
+
+    # Now let's test CACHE_BUCKET copying (Medium-path)
+    # 1. Let's delete the files from USER_DATA_BUCKET's conversions directory
+    user_id = await file_service.user_service.get_user_id(user_email)
+
+    # Clean USER_DATA_BUCKET conversions
+    for idx in range(len(png_pages_first)):
+        png_storage_key = get_conversion_png_path(
+            user_id=user_id,
+            file_id=file_id,
+            page_index=idx,
+            file_md5=file_info.md5 or "nomd5",
+        )
+        await file_service.blob_storage.delete(USER_DATA_BUCKET, png_storage_key)
+
+    # 2. Add records to NotePageContentDO and put dummy images in CACHE_BUCKET
+    async with session_manager.session() as session:
+        await session.execute(
+            delete(NotePageContentDO).where(NotePageContentDO.file_id == file_id)
+        )
+        for idx in range(len(png_pages_first)):
+            page_id = f"page_id_mock_{idx}"
+            content = NotePageContentDO(
+                file_id=file_id,
+                page_index=idx,
+                page_id=page_id,
+                content_hash=f"mock_hash_{idx}",
+            )
+            session.add(content)
+            # Write mock PNG to CACHE_BUCKET
+            cache_png_key = get_page_png_path(file_id, page_id)
+            await file_service.blob_storage.put(
+                CACHE_BUCKET, cache_png_key, b"mock_png_bytes"
+            )
+        await session.commit()
+
+    # 3. Request conversion: should succeed by copying from CACHE_BUCKET to USER_DATA_BUCKET!
+    png_pages_third = await device_client.get_note_png_pages(file_id)
+    assert len(png_pages_third) == len(png_pages_first)
+
+    # Let's verify that the files copied to USER_DATA_BUCKET actually contain our mock_png_bytes!
+    for idx in range(len(png_pages_first)):
+        png_storage_key = get_conversion_png_path(
+            user_id=user_id,
+            file_id=file_id,
+            page_index=idx,
+            file_md5=file_info.md5 or "nomd5",
+        )
+        # Read from USER_DATA_BUCKET
+        chunks = []
+        async for chunk in file_service.blob_storage.get(
+            USER_DATA_BUCKET, png_storage_key
+        ):
+            chunks.append(chunk)
+        assert b"".join(chunks) == b"mock_png_bytes"

--- a/tests/server/device/test_file_conversion.py
+++ b/tests/server/device/test_file_conversion.py
@@ -61,7 +61,7 @@ async def test_note_png_caching(
     test_note_path: Path,
     session_manager: DatabaseSessionManager,
 ) -> None:
-    # 1. Setup: Upload the test note
+    # Setup: Upload the test note
     with test_note_path.open("rb") as f:
         note_content = f.read()
 
@@ -95,7 +95,7 @@ async def test_note_png_caching(
     assert len(png_pages_second) == len(png_pages_first)
 
     # Now let's test CACHE_BUCKET copying (Medium-path)
-    # 1. Let's delete the files from USER_DATA_BUCKET's conversions directory
+    # Delete the files from USER_DATA_BUCKET's conversions directory
     user_id = await file_service.user_service.get_user_id(user_email)
 
     # Clean USER_DATA_BUCKET conversions
@@ -104,11 +104,11 @@ async def test_note_png_caching(
             user_id=user_id,
             file_id=file_id,
             page_index=idx,
-            file_md5=file_info.md5 or "nomd5",
+            file_md5=file_info.md5,
         )
         await file_service.blob_storage.delete(USER_DATA_BUCKET, png_storage_key)
 
-    # 2. Add records to NotePageContentDO and put dummy images in CACHE_BUCKET
+    # Add records to NotePageContentDO and put dummy images in CACHE_BUCKET
     async with session_manager.session() as session:
         await session.execute(
             delete(NotePageContentDO).where(NotePageContentDO.file_id == file_id)
@@ -129,7 +129,7 @@ async def test_note_png_caching(
             )
         await session.commit()
 
-    # 3. Request conversion: should succeed by copying from CACHE_BUCKET to USER_DATA_BUCKET!
+    # Request conversion: should succeed by copying from CACHE_BUCKET to USER_DATA_BUCKET!
     png_pages_third = await device_client.get_note_png_pages(file_id)
     assert len(png_pages_third) == len(png_pages_first)
 
@@ -139,7 +139,7 @@ async def test_note_png_caching(
             user_id=user_id,
             file_id=file_id,
             page_index=idx,
-            file_md5=file_info.md5 or "nomd5",
+            file_md5=file_info.md5,
         )
         # Read from USER_DATA_BUCKET
         chunks = []

--- a/tests/server/equipment/test_login.py
+++ b/tests/server/equipment/test_login.py
@@ -28,14 +28,16 @@ async def test_trace_logging(client: TestClient, mock_trace_log: str) -> None:
     await client.get("/some/random/path")
 
     log_file = Path(mock_trace_log)
-    # Wait for the async file write thread to finish writing
+    # Wait for the async file write thread to finish writing and flushing
+    content = ""
     for _ in range(20):
         if log_file.exists():
-            break
+            content = log_file.read_text()
+            if "/some/random/path" in content:
+                break
         await asyncio.sleep(0.05)
 
     assert log_file.exists()
-    content = log_file.read_text()
     assert "/some/random/path" in content
     assert "GET" in content
 

--- a/tests/server/test_trace.py
+++ b/tests/server/test_trace.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 
@@ -25,11 +26,16 @@ async def test_trace_logging(
 
     # Check trace log
     log_path = Path(mock_trace_log)
-    assert log_path.exists()
+    content = ""
+    # Wait for the async file write thread to finish writing and flushing
+    for _ in range(20):
+        if log_path.exists():
+            content = log_path.read_text().strip()
+            if "/api/file/query/server" in content:
+                break
+        await asyncio.sleep(0.05)
 
-    # Since we use indent=2, a single entry spans multiple lines.
-    # In this test we only made one request, so we can just parse the whole file.
-    content = log_path.read_text().strip()
+    assert log_path.exists()
     entry = json.loads(content)
 
     # Check request fields


### PR DESCRIPTION
Implements a caching layer for `/api/file/note/to/png` to reuse already converted pages in both `USER_DATA_BUCKET` and `CACHE_BUCKET` directories.