### PR TITLE
Add .gitattributes to normalise line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalise line endings so a contributor's platform does not affect the diff.
+* text=auto eol=lf
+
+# Binary fixtures: never normalise, never diff line by line.
+*.png binary
+*.jpg binary
+*.ico binary
+*.note binary
+*.sqlite binary


### PR DESCRIPTION
Git stores whatever line endings a contributor commits, so a change authored on Windows can arrive as CRLF. Every line of the file then reads as modified and the diff becomes unreviewable.

`* text=auto eol=lf` stores text files with LF regardless of the contributor's platform. The binary patterns cover the `.note` fixtures under `tests/testdata` and the image assets, so Git neither normalises their contents nor tries to diff them line by line.

This is preventive rather than a fix: the tree has no CRLF files today, and `git add --renormalize .` after adding this file rewrites nothing, so it changes no existing content.