### PR TITLE
Accept a JSON number where an API code is spelled as a string

### DIFF
--- a/supernote/models/base.py
+++ b/supernote/models/base.py
@@ -41,6 +41,15 @@ class BaseEnum(Enum):
                 return member
         raise ValueError(f"Invalid {cls.__name__} value: {value}")
 
+    @classmethod
+    def _missing_(cls, value: object) -> Self | None:
+        """Accept a JSON number where the API spells a code as a string."""
+        text = str(value)
+        for member in cls:
+            if member.value == text:
+                return member
+        return None
+
 
 class BooleanEnum(str, BaseEnum):
     """Boolean enum."""

--- a/tests/models/test_auth_completeness.py
+++ b/tests/models/test_auth_completeness.py
@@ -2,6 +2,8 @@
 
 from supernote.models.auth import (
     EmailDTO,
+    LoginDTO,
+    LoginMethod,
     ValidCodeDTO,
 )
 
@@ -18,3 +20,29 @@ def test_valid_code_dto() -> None:
     data = dto.to_dict()
     assert data["validCodeKey"] == "key123"
     assert data["validCode"] == "123456"
+
+
+def test_login_dto_accepts_a_numeric_login_method() -> None:
+    """The Partner apps send loginMethod as a JSON number."""
+    dto = LoginDTO.from_dict(
+        {
+            "account": "user@example.com",
+            "password": "deadbeef",
+            "timestamp": "1785468843354",
+            "loginMethod": 2,
+        }
+    )
+    assert dto.login_method is LoginMethod.EMAIL
+
+
+def test_login_dto_accepts_a_string_login_method() -> None:
+    """The device sends it as a string."""
+    dto = LoginDTO.from_dict(
+        {
+            "account": "user@example.com",
+            "password": "deadbeef",
+            "timestamp": "1785468843354",
+            "loginMethod": "2",
+        }
+    )
+    assert dto.login_method is LoginMethod.EMAIL

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,6 +1,9 @@
 """Tests for base models."""
 
-from supernote.models.base import create_error_response
+import pytest
+
+from supernote.models.auth import LoginMethod
+from supernote.models.base import BooleanEnum, create_error_response
 
 
 def test_create_error_response() -> None:
@@ -8,3 +11,34 @@ def test_create_error_response() -> None:
     error_response = create_error_response("test error")
     assert error_response.error_msg == "test error"
     assert error_response.error_code is None
+
+
+def test_enum_accepts_a_string_code() -> None:
+    """Codes are defined as strings and the device sends them that way."""
+    assert LoginMethod("2") is LoginMethod.EMAIL
+
+
+def test_enum_accepts_a_json_number() -> None:
+    """The official Partner apps send {"loginMethod": 2}."""
+    assert LoginMethod(1) is LoginMethod.PHONE
+    assert LoginMethod(2) is LoginMethod.EMAIL
+    assert LoginMethod(3) is LoginMethod.WECHAT
+
+
+def test_enum_rejects_an_unknown_code() -> None:
+    with pytest.raises(ValueError):
+        LoginMethod(9)
+    with pytest.raises(ValueError):
+        LoginMethod("9")
+
+
+def test_enum_rejects_a_bool() -> None:
+    """A bool is not one of the codes."""
+    with pytest.raises(ValueError):
+        LoginMethod(True)
+
+
+def test_non_numeric_enum_is_unaffected() -> None:
+    assert BooleanEnum("Y") is BooleanEnum.YES
+    with pytest.raises(ValueError):
+        BooleanEnum(1)


### PR DESCRIPTION
The codes in these enums are defined as strings, and the Supernote device sends them that way. The official Partner apps send JSON numbers instead: a login from the mobile app arrives as `{"loginMethod": 2}` rather than `{"loginMethod": "2"}`. Deserialisation raises, and `POST /api/official/user/account/login/new` returns 500 before it ever checks the password.

Reproduced on `main` before the change:

```
device      -> OK, login_method=<LoginMethod.EMAIL: 2>
mobile app  -> InvalidFieldValue: Field "login_method" of type LoginMethod
               in LoginDTO has invalid value 2
```

The coercion lives on `BaseEnum` rather than `LoginMethod`, because every code in this dialect is stringly typed, so fixing one enum just moves the failure to the next DTO the app touches.

Only an exact match against an existing member is accepted, so an unknown code is still rejected. Booleans and non-integral floats are excluded explicitly, since without that `True` would resolve to the code `"1"`.

8 tests cover both payload shapes, the rejections, and that non-numeric enums such as `BooleanEnum` are unaffected. The full suite passes on this branch: 495 passed, 47 snapshots.

Context: this is one of several gaps I hit pointing the Partner app at a self-hosted server, related to #107.