### PR TITLE
security: enforce signature requirement on Socket.IO handshake

### DIFF
--- a/supernote/server/socket_auth.py
+++ b/supernote/server/socket_auth.py
@@ -22,11 +22,11 @@ def verify_handshake_signature(params: SocketHandshakeParams, secret_key: str) -
         secret_key: Server authentication secret key.
 
     Returns:
-        True if the signature is valid or omitted for dev testing, False otherwise.
+        True if the signature is valid, False otherwise.
     """
     if not params.sign:
-        # If signature is not provided, allow connection in lenient dev mode
-        return True
+        logger.warning("Missing signature in Socket.IO handshake")
+        return False
 
     raw = f"{params.token}_{params.type}_{params.random}"
     expected_sign = hashlib.md5(raw.encode("utf-8")).hexdigest()

--- a/tests/server/test_socket_auth.py
+++ b/tests/server/test_socket_auth.py
@@ -68,7 +68,7 @@ def test_verify_handshake_signature_missing_sign() -> None:
         random="rnd123",
         sign="",
     )
-    assert verify_handshake_signature(params, "secret") is True
+    assert verify_handshake_signature(params, "secret") is False
 
 
 def test_verify_handshake_token_valid() -> None:


### PR DESCRIPTION
Fixes security issue where missing signature parameters bypassed Socket.IO handshake authentication.