### PR TITLE
feat(schedule): align schedule routes and client with OpenAPI spec

### DIFF
--- a/api-spec/components/schemas/schedule.yaml
+++ b/api-spec/components/schemas/schedule.yaml
@@ -329,6 +329,8 @@ UpdateScheduleTaskListDTO:
 ScheduleTaskDTO:
   type: object
   properties:
+    taskListId:
+      type: string
     maxResults:
       type: string
     nextPageTokens:

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -137,13 +137,12 @@ class ScheduleClient:
         """
         page_token = None
         while True:
-            dto = ScheduleTaskDTO(next_page_tokens=page_token)
-            json_data = dto.to_dict()
-            if group_id:
-                json_data["taskListId"] = str(group_id)
-
+            dto = ScheduleTaskDTO(
+                task_list_id=str(group_id) if group_id else None,
+                next_page_tokens=page_token,
+            )
             response = await self._client.post_json(
-                "/api/file/schedule/task/all", ScheduleTaskAllVO, json=json_data
+                "/api/file/schedule/task/all", ScheduleTaskAllVO, json=dto.to_dict()
             )
 
             for item in response.schedule_task:

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -1,18 +1,23 @@
 import time
 from collections.abc import AsyncIterator
-from typing import Any
 
-from supernote.models.base import BooleanEnum
+from supernote.models.base import BaseResponse, BooleanEnum
 from supernote.models.schedule import (
     AddScheduleTaskDTO,
     AddScheduleTaskGroupDTO,
     AddScheduleTaskGroupVO,
     AddScheduleTaskVO,
+    ClearScheduleTaskGroupDTO,
+    GetScheduleTaskGroupVO,
     ScheduleTaskAllVO,
+    ScheduleTaskDTO,
+    ScheduleTaskGroupDTO,
     ScheduleTaskGroupItem,
     ScheduleTaskGroupVO,
     ScheduleTaskInfo,
+    ScheduleTaskVO,
     UpdateScheduleTaskDTO,
+    UpdateScheduleTaskGroupDTO,
     UpdateScheduleTaskVO,
 )
 
@@ -30,26 +35,50 @@ class ScheduleClient:
         """Create a new schedule group."""
         dto = AddScheduleTaskGroupDTO(title=title)
         return await self._client.post_json(
-            "/api/schedule/groups", AddScheduleTaskGroupVO, json=dto.to_dict()
+            "/api/file/schedule/group", AddScheduleTaskGroupVO, json=dto.to_dict()
+        )
+
+    async def get_group(self, group_id: int) -> GetScheduleTaskGroupVO:
+        """Get a schedule group by ID."""
+        return await self._client.get_json(
+            f"/api/file/schedule/group/{group_id}", GetScheduleTaskGroupVO
+        )
+
+    async def update_group(self, group_id: int, title: str) -> BaseResponse:
+        """Update a schedule group."""
+        dto = UpdateScheduleTaskGroupDTO(
+            task_list_id=str(group_id),
+            title=title,
+            last_modified=int(time.time() * 1000),
+        )
+        return await self._client.put_json(
+            "/api/file/schedule/group", BaseResponse, json=dto.to_dict()
+        )
+
+    async def clear_group(self, group_id: int) -> BaseResponse:
+        """Clear all tasks within a schedule group."""
+        dto = ClearScheduleTaskGroupDTO(
+            task_list_id=str(group_id), last_modified=int(time.time() * 1000)
+        )
+        return await self._client.post_json(
+            "/api/file/schedule/group/clear", BaseResponse, json=dto.to_dict()
         )
 
     async def list_groups(self) -> AsyncIterator[ScheduleTaskGroupItem]:
         """List all schedule groups.
 
         This is a generator that yields groups one by one. It pages
-        through the results and yields each group as it is received.
+        through the results using pageToken and yields each group as it is received.
 
         Yields:
             ScheduleTaskGroupItem: A schedule group.
         """
         page_token = None
         while True:
-            params: dict[str, Any] = {}
-            if page_token:
-                params["pageToken"] = page_token
-
-            response = await self._client.get_json(
-                "/api/schedule/groups", ScheduleTaskGroupVO, params=params
+            dto = ScheduleTaskGroupDTO(page_token=page_token)
+            json_data = {k: v for k, v in dto.to_dict().items() if v is not None}
+            response = await self._client.post_json(
+                "/api/file/schedule/group/all", ScheduleTaskGroupVO, json=json_data
             )
 
             for item in response.schedule_task_group:
@@ -61,7 +90,7 @@ class ScheduleClient:
 
     async def delete_group(self, group_id: int) -> None:
         """Delete a schedule group."""
-        await self._client.request("delete", f"/api/schedule/groups/{group_id}")
+        await self._client.request("delete", f"/api/file/schedule/group/{group_id}")
 
     async def create_task(
         self,
@@ -86,23 +115,39 @@ class ScheduleClient:
             is_reminder_on=BooleanEnum.of(is_reminder_on),
         )
         return await self._client.post_json(
-            "/api/schedule/tasks", AddScheduleTaskVO, json=dto.to_dict()
+            "/api/file/schedule/task", AddScheduleTaskVO, json=dto.to_dict()
+        )
+
+    async def get_task(self, task_id: int) -> ScheduleTaskVO:
+        """Get details for a single task."""
+        return await self._client.get_json(
+            f"/api/file/schedule/task/{task_id}", ScheduleTaskVO
         )
 
     async def list_tasks(
         self, group_id: int | None = None
     ) -> AsyncIterator[ScheduleTaskInfo]:
-        """List all schedule tasks."""
+        """List all schedule tasks.
+
+        This is a generator that yields tasks one by one. It pages
+        through the results using nextPageTokens and yields each task
+        as it is received.
+
+        Yields:
+            ScheduleTaskInfo: A schedule task.
+        """
         next_page_tokens = None
         while True:
-            params: dict[str, Any] = {}
+            dto = ScheduleTaskDTO(
+                max_results=None,
+                next_page_tokens=next_page_tokens,
+            )
+            json_data = {k: v for k, v in dto.to_dict().items() if v is not None}
             if group_id:
-                params["taskListId"] = str(group_id)
-            if next_page_tokens:
-                params["nextPageTokens"] = next_page_tokens
+                json_data["taskListId"] = str(group_id)
 
-            response = await self._client.get_json(
-                "/api/schedule/tasks", ScheduleTaskAllVO, params=params
+            response = await self._client.post_json(
+                "/api/file/schedule/task/all", ScheduleTaskAllVO, json=json_data
             )
 
             for item in response.schedule_task:
@@ -142,9 +187,9 @@ class ScheduleClient:
             last_modified=int(time.time() * 1000),
         )
         return await self._client.put_json(
-            f"/api/schedule/tasks/{task_id}", UpdateScheduleTaskVO, json=dto.to_dict()
+            "/api/file/schedule/task", UpdateScheduleTaskVO, json=dto.to_dict()
         )
 
     async def delete_task(self, task_id: int) -> None:
         """Delete a schedule task."""
-        await self._client.request("delete", f"/api/schedule/tasks/{task_id}")
+        await self._client.request("delete", f"/api/file/schedule/task/{task_id}")

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -76,9 +76,8 @@ class ScheduleClient:
         page_token = None
         while True:
             dto = ScheduleTaskGroupDTO(page_token=page_token)
-            json_data = {k: v for k, v in dto.to_dict().items() if v is not None}
             response = await self._client.post_json(
-                "/api/file/schedule/group/all", ScheduleTaskGroupVO, json=json_data
+                "/api/file/schedule/group/all", ScheduleTaskGroupVO, json=dto.to_dict()
             )
 
             for item in response.schedule_task_group:
@@ -136,13 +135,10 @@ class ScheduleClient:
         Yields:
             ScheduleTaskInfo: A schedule task.
         """
-        next_page_tokens = None
+        page_token = None
         while True:
-            dto = ScheduleTaskDTO(
-                max_results=None,
-                next_page_tokens=next_page_tokens,
-            )
-            json_data = {k: v for k, v in dto.to_dict().items() if v is not None}
+            dto = ScheduleTaskDTO(next_page_tokens=page_token)
+            json_data = dto.to_dict()
             if group_id:
                 json_data["taskListId"] = str(group_id)
 
@@ -153,8 +149,8 @@ class ScheduleClient:
             for item in response.schedule_task:
                 yield item
 
-            next_page_tokens = response.next_page_token
-            if not next_page_tokens:
+            page_token = response.next_page_token
+            if not page_token:
                 break
 
     async def update_task(

--- a/supernote/models/schedule.py
+++ b/supernote/models/schedule.py
@@ -423,6 +423,9 @@ class ScheduleTaskDTO(DataClassJSONMixin):
         /api/file/schedule/task/all (POST)
     """
 
+    task_list_id: str | None = field(
+        metadata=field_options(alias="taskListId"), default=None
+    )
     max_results: str | None = field(
         metadata=field_options(alias="maxResults"), default=None
     )

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -3,19 +3,25 @@ from typing import Any
 
 from aiohttp import web
 
-from supernote.models.base import BaseResponse, BooleanEnum, create_error_response
+from supernote.models.base import BaseResponse, BooleanEnum
 from supernote.models.schedule import (
     AddScheduleTaskDTO,
     AddScheduleTaskGroupDTO,
     AddScheduleTaskGroupVO,
     AddScheduleTaskVO,
+    ClearScheduleTaskGroupDTO,
+    GetScheduleTaskGroupVO,
     ScheduleTaskAllVO,
     ScheduleTaskGroupItem,
     ScheduleTaskGroupVO,
     ScheduleTaskInfo,
+    ScheduleTaskVO,
     UpdateScheduleTaskDTO,
+    UpdateScheduleTaskGroupDTO,
+    UpdateScheduleTaskListDTO,
     UpdateScheduleTaskVO,
 )
+from supernote.server.exceptions import SupernoteError
 from supernote.server.services.schedule import ScheduleService
 
 logger = logging.getLogger(__name__)
@@ -23,96 +29,169 @@ logger = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
 
-@routes.post("/api/schedule/groups")
+@routes.post("/api/file/schedule/group")
 async def create_group(request: web.Request) -> web.Response:
-    user = request["user"]
     try:
         data = await request.json()
         dto = AddScheduleTaskGroupDTO.from_dict(data)
-    except Exception as e:
-        return web.json_response(
-            create_error_response(f"Invalid request: {e}").to_dict(), status=400
-        )
+        if not dto.title:
+            raise SupernoteError("Title required", status_code=400)
 
-    if not dto.title:
-        return web.json_response(
-            create_error_response("Title required").to_dict(), status=400
-        )
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
 
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
-
-    try:
         group = await schedule_service.create_group(user_id, dto.title)
         return web.json_response(
             AddScheduleTaskGroupVO(
                 success=True, task_list_id=str(group.task_list_id)
             ).to_dict()
         )
-    except ValueError as e:
-        return web.json_response(create_error_response(str(e)).to_dict(), status=400)
+    except SupernoteError as err:
+        return err.to_response()
+    except ValueError as err:
+        return SupernoteError(str(err), status_code=400).to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
 
-@routes.get("/api/schedule/groups")
-async def list_groups(request: web.Request) -> web.Response:
-    user = request["user"]
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
+@routes.put("/api/file/schedule/group")
+async def update_group(request: web.Request) -> web.Response:
+    try:
+        data = await request.json()
+        dto = UpdateScheduleTaskGroupDTO.from_dict(data)
+        if not dto.task_list_id or not dto.title:
+            raise SupernoteError("Missing required fields", status_code=400)
 
-    groups = await schedule_service.list_groups(user_id)
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
 
-    # Map to ScheduleTaskGroupItem
-    items = [
-        ScheduleTaskGroupItem(
-            task_list_id=str(g.task_list_id),
-            user_id=g.user_id,
-            title=g.title,
-            create_time=g.create_time,
+        group = await schedule_service.update_group(
+            user_id, int(dto.task_list_id), dto.title
         )
-        for g in groups
-    ]
+        if not group:
+            raise SupernoteError("Not found", status_code=404)
+        return web.json_response(BaseResponse(success=True).to_dict())
+    except SupernoteError as err:
+        return err.to_response()
+    except ValueError as err:
+        return SupernoteError(str(err), status_code=400).to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
-    return web.json_response(
-        ScheduleTaskGroupVO(success=True, schedule_task_group=items).to_dict()
-    )
 
-
-@routes.delete("/api/schedule/groups/{id}")
+@routes.delete("/api/file/schedule/group/{taskListId}")
 async def delete_group(request: web.Request) -> web.Response:
-    user = request["user"]
-    group_id = int(request.match_info["id"])
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
+    try:
+        group_id_str = request.match_info.get("taskListId")
+        if not group_id_str:
+            raise SupernoteError("Missing taskListId", status_code=400)
 
-    success = await schedule_service.delete_group(user_id, group_id)
-    if not success:
+        group_id = int(group_id_str)
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        success = await schedule_service.delete_group(user_id, group_id)
+        if not success:
+            raise SupernoteError("Not found", status_code=404)
+
+        return web.json_response(BaseResponse(success=True).to_dict())
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
+
+
+@routes.get("/api/file/schedule/group/{taskListId}")
+async def get_group(request: web.Request) -> web.Response:
+    try:
+        group_id_str = request.match_info.get("taskListId")
+        if not group_id_str:
+            raise SupernoteError("Missing taskListId", status_code=400)
+
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        group = await schedule_service.get_group(user_id, int(group_id_str))
+        if not group:
+            raise SupernoteError("Not found", status_code=404)
+
         return web.json_response(
-            create_error_response("Not found").to_dict(), status=404
+            GetScheduleTaskGroupVO(
+                success=True,
+                task_list_id=str(group.task_list_id),
+                user_id=group.user_id,
+                title=group.title,
+                create_time=group.create_time,
+            ).to_dict()
         )
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
-    return web.json_response(BaseResponse(success=True).to_dict())
+
+@routes.post("/api/file/schedule/group/clear")
+async def clear_group(request: web.Request) -> web.Response:
+    try:
+        data = await request.json()
+        dto = ClearScheduleTaskGroupDTO.from_dict(data)
+
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        await schedule_service.clear_group(user_id, int(dto.task_list_id))
+        return web.json_response(BaseResponse(success=True).to_dict())
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
 
-@routes.post("/api/schedule/tasks")
+@routes.post("/api/file/schedule/group/all")
+async def list_groups(request: web.Request) -> web.Response:
+    try:
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        groups = await schedule_service.list_groups(user_id)
+
+        items = [
+            ScheduleTaskGroupItem(
+                task_list_id=str(g.task_list_id),
+                user_id=g.user_id,
+                title=g.title,
+                create_time=g.create_time,
+            )
+            for g in groups
+        ]
+
+        return web.json_response(
+            ScheduleTaskGroupVO(success=True, schedule_task_group=items).to_dict()
+        )
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
+
+
+@routes.post("/api/file/schedule/task")
 async def create_task(request: web.Request) -> web.Response:
-    user = request["user"]
     try:
         data = await request.json()
         dto = AddScheduleTaskDTO.from_dict(data)
-    except Exception as e:
-        return web.json_response(
-            create_error_response(f"Invalid request: {e}").to_dict(), status=400
-        )
+        if not dto.task_list_id or not dto.title:
+            raise SupernoteError("Missing required fields", status_code=400)
 
-    if not dto.task_list_id or not dto.title:
-        return web.json_response(
-            create_error_response("Missing required fields").to_dict(), status=400
-        )
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
 
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
-
-    try:
         task = await schedule_service.create_task(
             user_id=user_id,
             group_id=int(dto.task_list_id),
@@ -127,97 +206,220 @@ async def create_task(request: web.Request) -> web.Response:
         return web.json_response(
             AddScheduleTaskVO(success=True, task_id=str(task.task_id)).to_dict()
         )
-    except ValueError as e:
-        return web.json_response(create_error_response(str(e)).to_dict(), status=400)
+    except SupernoteError as err:
+        return err.to_response()
+    except ValueError as err:
+        return SupernoteError(str(err), status_code=400).to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
 
-@routes.get("/api/schedule/tasks")
-async def list_tasks(request: web.Request) -> web.Response:
-    user = request["user"]
-    group_id_str = request.query.get("taskListId")
-    group_id = int(group_id_str) if group_id_str else None
-
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
-
-    tasks_dos = await schedule_service.list_tasks(user_id, group_id)
-
-    tasks_vos = [
-        ScheduleTaskInfo(
-            task_id=str(t.task_id),
-            task_list_id=str(t.task_list_id),
-            title=t.title,
-            detail=t.detail,
-            status=t.status,
-            importance=t.importance,
-            due_time=t.due_time,
-            recurrence=t.recurrence,
-            is_reminder_on=(BooleanEnum.YES if t.is_reminder_on else BooleanEnum.NO),
-            last_modified=t.update_time,
-        )
-        for t in tasks_dos
-    ]
-
-    return web.json_response(
-        ScheduleTaskAllVO(success=True, schedule_task=tasks_vos).to_dict()
-    )
-
-
-@routes.put("/api/schedule/tasks/{id}")
+@routes.put("/api/file/schedule/task")
 async def update_task(request: web.Request) -> web.Response:
-    user = request["user"]
-    task_id = int(request.match_info["id"])
     try:
         data = await request.json()
         dto = UpdateScheduleTaskDTO.from_dict(data)
-    except Exception as e:
+        if not dto.task_id:
+            raise SupernoteError("Missing taskId", status_code=400)
+
+        task_id = int(dto.task_id)
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        updates: dict[str, Any] = {}
+        if dto.title is not None:
+            updates["title"] = dto.title
+        if dto.detail is not None:
+            updates["detail"] = dto.detail
+        if dto.status is not None:
+            updates["status"] = dto.status
+        if dto.importance is not None:
+            updates["importance"] = dto.importance
+        if dto.due_time is not None:
+            updates["due_time"] = dto.due_time
+        if dto.recurrence is not None:
+            updates["recurrence"] = dto.recurrence
+        if dto.is_reminder_on is not None:
+            updates["is_reminder_on"] = dto.is_reminder_on == BooleanEnum.YES
+        if dto.task_list_id is not None:
+            updates["task_list_id"] = int(dto.task_list_id)
+
+        updated_task = await schedule_service.update_task(user_id, task_id, **updates)
+        if not updated_task:
+            raise SupernoteError("Not found", status_code=404)
+
         return web.json_response(
-            create_error_response(f"Invalid request: {e}").to_dict(), status=400
+            UpdateScheduleTaskVO(
+                success=True, task_id=str(updated_task.task_id)
+            ).to_dict()
         )
-
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
-
-    updates: dict[str, Any] = {}
-    if dto.title is not None:
-        updates["title"] = dto.title
-    if dto.detail is not None:
-        updates["detail"] = dto.detail
-    if dto.status is not None:
-        updates["status"] = dto.status
-    if dto.importance is not None:
-        updates["importance"] = dto.importance
-    if dto.due_time is not None:
-        updates["due_time"] = dto.due_time
-    if dto.recurrence is not None:
-        updates["recurrence"] = dto.recurrence
-    if dto.is_reminder_on is not None:
-        updates["is_reminder_on"] = dto.is_reminder_on == BooleanEnum.YES
-    if dto.task_list_id is not None:
-        updates["task_list_id"] = int(dto.task_list_id)
-
-    updated_task = await schedule_service.update_task(user_id, task_id, **updates)
-    if not updated_task:
-        return web.json_response(
-            create_error_response("Not found").to_dict(), status=404
-        )
-
-    return web.json_response(
-        UpdateScheduleTaskVO(success=True, task_id=str(updated_task.task_id)).to_dict()
-    )
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
 
-@routes.delete("/api/schedule/tasks/{id}")
+@routes.put("/api/file/schedule/task/list")
+async def batch_update_task_list(request: web.Request) -> web.Response:
+    try:
+        data = await request.json()
+        dto = UpdateScheduleTaskListDTO.from_dict(data)
+
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        for item in dto.update_schedule_task_list:
+            if item.task_id:
+                updates: dict[str, Any] = {}
+                if item.title is not None:
+                    updates["title"] = item.title
+                if item.detail is not None:
+                    updates["detail"] = item.detail
+                if item.status is not None:
+                    updates["status"] = item.status
+                if item.importance is not None:
+                    updates["importance"] = item.importance
+                if item.due_time is not None:
+                    updates["due_time"] = item.due_time
+                if item.recurrence is not None:
+                    updates["recurrence"] = item.recurrence
+                if item.is_reminder_on is not None:
+                    updates["is_reminder_on"] = item.is_reminder_on == BooleanEnum.YES
+                await schedule_service.update_task(
+                    user_id, int(item.task_id), **updates
+                )
+
+        return web.json_response(BaseResponse(success=True).to_dict())
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
+
+
+@routes.delete("/api/file/schedule/task/{taskId}")
 async def delete_task(request: web.Request) -> web.Response:
-    user = request["user"]
-    task_id = int(request.match_info["id"])
-    schedule_service: ScheduleService = request.app["schedule_service"]
-    user_id = await request.app["user_service"].get_user_id(user)
+    try:
+        task_id_str = request.match_info.get("taskId")
+        if not task_id_str:
+            raise SupernoteError("Missing taskId", status_code=400)
 
-    success = await schedule_service.delete_task(user_id, task_id)
-    if not success:
+        task_id = int(task_id_str)
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        success = await schedule_service.delete_task(user_id, task_id)
+        if not success:
+            raise SupernoteError("Not found", status_code=404)
+
+        return web.json_response(BaseResponse(success=True).to_dict())
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
+
+
+@routes.get("/api/file/schedule/task/{taskId}")
+async def get_task(request: web.Request) -> web.Response:
+    try:
+        task_id_str = request.match_info.get("taskId")
+        if not task_id_str:
+            raise SupernoteError("Missing taskId", status_code=400)
+
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        task = await schedule_service.get_task(user_id, int(task_id_str))
+        if not task:
+            raise SupernoteError("Not found", status_code=404)
+
         return web.json_response(
-            create_error_response("Not found").to_dict(), status=404
+            ScheduleTaskVO(
+                success=True,
+                task_id=task.task_id,
+                task_list_id=task.task_list_id,
+                title=task.title,
+                detail=task.detail,
+                status=task.status,
+                importance=task.importance,
+                due_time=task.due_time,
+                recurrence=task.recurrence,
+                is_reminder_on=(
+                    BooleanEnum.YES if task.is_reminder_on else BooleanEnum.NO
+                ),
+                last_modified=task.update_time,
+            ).to_dict()
         )
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
 
-    return web.json_response(BaseResponse(success=True).to_dict())
+
+@routes.post("/api/file/schedule/task/all")
+async def list_tasks(request: web.Request) -> web.Response:
+    try:
+        group_id_str = None
+        try:
+            data = await request.json()
+            group_id_str = data.get("taskListId")
+        except Exception:
+            pass
+
+        group_id = int(group_id_str) if group_id_str else None
+
+        user = request["user"]
+        schedule_service: ScheduleService = request.app["schedule_service"]
+        user_id = await request.app["user_service"].get_user_id(user)
+
+        tasks_dos = await schedule_service.list_tasks(user_id, group_id)
+
+        tasks_vos = [
+            ScheduleTaskInfo(
+                task_id=str(t.task_id),
+                task_list_id=str(t.task_list_id),
+                title=t.title,
+                detail=t.detail,
+                status=t.status,
+                importance=t.importance,
+                due_time=t.due_time,
+                recurrence=t.recurrence,
+                is_reminder_on=(
+                    BooleanEnum.YES if t.is_reminder_on else BooleanEnum.NO
+                ),
+                last_modified=t.update_time,
+            )
+            for t in tasks_dos
+        ]
+
+        return web.json_response(
+            ScheduleTaskAllVO(success=True, schedule_task=tasks_vos).to_dict()
+        )
+    except SupernoteError as err:
+        return err.to_response()
+    except Exception as err:
+        return SupernoteError.uncaught(err).to_response()
+
+
+# Placeholder Sort Endpoints (501 Not Implemented as requested for features pending backend support)
+@routes.post("/api/file/schedule/sort")
+async def add_sort(request: web.Request) -> web.Response:
+    return SupernoteError("Not implemented", status_code=501).to_response()
+
+
+@routes.put("/api/file/schedule/sort")
+async def update_sort(request: web.Request) -> web.Response:
+    return SupernoteError("Not implemented", status_code=501).to_response()
+
+
+@routes.delete("/api/file/schedule/sort/{taskListId}")
+async def delete_sort(request: web.Request) -> web.Response:
+    return SupernoteError("Not implemented", status_code=501).to_response()
+
+
+@routes.post("/api/file/query/schedule/sort")
+async def get_sort(request: web.Request) -> web.Response:
+    return SupernoteError("Not implemented", status_code=501).to_response()

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -270,9 +270,10 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
+        updates_list: list[dict[str, Any]] = []
         for item in dto.update_schedule_task_list:
             if item.task_id:
-                updates: dict[str, Any] = {}
+                updates: dict[str, Any] = {"task_id": int(item.task_id)}
                 if item.title is not None:
                     updates["title"] = item.title
                 if item.detail is not None:
@@ -287,13 +288,14 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
                     updates["recurrence"] = item.recurrence
                 if item.is_reminder_on is not None:
                     updates["is_reminder_on"] = item.is_reminder_on == BooleanEnum.YES
-                await schedule_service.update_task(
-                    user_id, int(item.task_id), **updates
-                )
+                updates_list.append(updates)
 
+        await schedule_service.batch_update_tasks(user_id, updates_list)
         return web.json_response(BaseResponse(success=True).to_dict())
     except SupernoteError as err:
         return err.to_response()
+    except ValueError as err:
+        return SupernoteError(str(err), status_code=400).to_response()
     except Exception as err:
         return SupernoteError.uncaught(err).to_response()
 

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -12,6 +12,7 @@ from supernote.models.schedule import (
     ClearScheduleTaskGroupDTO,
     GetScheduleTaskGroupVO,
     ScheduleTaskAllVO,
+    ScheduleTaskDTO,
     ScheduleTaskGroupItem,
     ScheduleTaskGroupVO,
     ScheduleTaskInfo,
@@ -364,14 +365,14 @@ async def get_task(request: web.Request) -> web.Response:
 @routes.post("/api/file/schedule/task/all")
 async def list_tasks(request: web.Request) -> web.Response:
     try:
-        group_id_str = None
+        group_id = None
         try:
             data = await request.json()
-            group_id_str = data.get("taskListId")
+            dto = ScheduleTaskDTO.from_dict(data)
+            if dto.task_list_id:
+                group_id = int(dto.task_list_id)
         except Exception:
             pass
-
-        group_id = int(group_id_str) if group_id_str else None
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -209,6 +209,55 @@ class ScheduleService:
             result = await session.execute(stmt_get)
             return result.scalar_one_or_none()
 
+    async def batch_update_tasks(
+        self, user_id: int, updates_list: list[dict[str, Any]]
+    ) -> bool:
+        """Batch update tasks atomically in a single transaction."""
+        allowed_fields = {
+            "title",
+            "detail",
+            "status",
+            "importance",
+            "due_time",
+            "completed_time",
+            "recurrence",
+            "is_reminder_on",
+            "task_list_id",
+        }
+        async with self.session_manager.session() as session:
+            for item in updates_list:
+                task_id = item.get("task_id")
+                if not task_id:
+                    continue
+                title = item.get("title")
+                if title is not None and len(title) > MAX_TITLE_LENGTH:
+                    raise ValueError("Title is too long")
+                detail = item.get("detail")
+                if detail is not None and len(detail) > MAX_DETAIL_LENGTH:
+                    raise ValueError("Detail is too long")
+
+                updates = {
+                    k: v
+                    for k, v in item.items()
+                    if k in allowed_fields and v is not None
+                }
+                if not updates:
+                    continue
+
+                stmt = (
+                    update(ScheduleTaskDO)
+                    .where(
+                        ScheduleTaskDO.user_id == user_id,
+                        ScheduleTaskDO.task_id == task_id,
+                    )
+                    .values(**updates)
+                )
+                res = await session.execute(stmt)
+                if getattr(res, "rowcount", 0) == 0:
+                    raise ValueError(f"Task {task_id} not found")
+            await session.commit()
+            return True
+
     async def delete_task(self, user_id: int, task_id: int) -> bool:
         """Delete a task."""
         async with self.session_manager.session() as session:

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -48,9 +48,57 @@ class ScheduleService:
             result = await session.execute(stmt)
             return list(result.scalars().all())
 
+    async def get_group(
+        self, user_id: int, group_id: int
+    ) -> ScheduleTaskGroupDO | None:
+        """Get a task group by ID."""
+        async with self.session_manager.session() as session:
+            stmt = select(ScheduleTaskGroupDO).where(
+                ScheduleTaskGroupDO.user_id == user_id,
+                ScheduleTaskGroupDO.task_list_id == group_id,
+            )
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
+
+    async def update_group(
+        self, user_id: int, group_id: int, title: str
+    ) -> ScheduleTaskGroupDO | None:
+        """Update a task group title."""
+        if len(title) > MAX_TITLE_LENGTH:
+            raise ValueError("Title is too long")
+        async with self.session_manager.session() as session:
+            stmt = (
+                update(ScheduleTaskGroupDO)
+                .where(
+                    ScheduleTaskGroupDO.user_id == user_id,
+                    ScheduleTaskGroupDO.task_list_id == group_id,
+                )
+                .values(title=title)
+                .execution_options(synchronize_session="fetch")
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+            stmt_get = select(ScheduleTaskGroupDO).where(
+                ScheduleTaskGroupDO.user_id == user_id,
+                ScheduleTaskGroupDO.task_list_id == group_id,
+            )
+            result = await session.execute(stmt_get)
+            return result.scalar_one_or_none()
+
+    async def clear_group(self, user_id: int, group_id: int) -> bool:
+        """Clear all tasks within a task group."""
+        async with self.session_manager.session() as session:
+            stmt = delete(ScheduleTaskDO).where(
+                ScheduleTaskDO.user_id == user_id,
+                ScheduleTaskDO.task_list_id == group_id,
+            )
+            await session.execute(stmt)
+            await session.commit()
+            return True
+
     async def delete_group(self, user_id: int, group_id: int) -> bool:
         """Delete a task group. Returns True if found and deleted."""
-        # TODO: Handle cascade delete of tasks?
         # For now, simplistic delete.
         async with self.session_manager.session() as session:
             stmt = delete(ScheduleTaskGroupDO).where(
@@ -97,6 +145,16 @@ class ScheduleService:
             await session.commit()
             await session.refresh(task)
             return task
+
+    async def get_task(self, user_id: int, task_id: int) -> ScheduleTaskDO | None:
+        """Get a task by ID."""
+        async with self.session_manager.session() as session:
+            stmt = select(ScheduleTaskDO).where(
+                ScheduleTaskDO.user_id == user_id,
+                ScheduleTaskDO.task_id == task_id,
+            )
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
 
     async def list_tasks(
         self,

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -250,3 +250,41 @@ async def test_batch_update_task_list_transactional_rollback(
     assert task2_detail.title == "Task 2"
 
     await schedule.delete_group(group_id)
+
+
+async def test_list_tasks_filtering_by_group_id(
+    authenticated_client: Client,
+) -> None:
+    schedule = ScheduleClient(authenticated_client)
+
+    group_a_vo = await schedule.create_group("Group A")
+    group_b_vo = await schedule.create_group("Group B")
+    assert group_a_vo.task_list_id is not None
+    assert group_b_vo.task_list_id is not None
+    group_a_id = int(group_a_vo.task_list_id)
+    group_b_id = int(group_b_vo.task_list_id)
+
+    task_a_vo = await schedule.create_task(group_a_id, "Task in Group A")
+    task_b_vo = await schedule.create_task(group_b_id, "Task in Group B")
+    assert task_a_vo.task_id is not None
+    assert task_b_vo.task_id is not None
+
+    # Filter by Group A
+    tasks_a = [t async for t in schedule.list_tasks(group_a_id)]
+    assert len(tasks_a) == 1
+    assert tasks_a[0].title == "Task in Group A"
+
+    # Filter by Group B
+    tasks_b = [t async for t in schedule.list_tasks(group_b_id)]
+    assert len(tasks_b) == 1
+    assert tasks_b[0].title == "Task in Group B"
+
+    # List all without group filter
+    all_tasks = [t async for t in schedule.list_tasks(group_id=None)]
+    assert len(all_tasks) == 2
+    titles = {t.title for t in all_tasks}
+    assert titles == {"Task in Group A", "Task in Group B"}
+
+    # Cleanup
+    await schedule.delete_group(group_a_id)
+    await schedule.delete_group(group_b_id)

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -24,7 +24,6 @@ async def authenticated_client(
         async def async_get_access_token(self) -> str:
             return token
 
-    # client is TestClient, client.session is ClientSession
     base_url = str(client.make_url(""))
     return Client(client.session, auth=TokenAuth(), host=base_url)
 
@@ -32,22 +31,21 @@ async def authenticated_client(
 async def test_schedule_flow(authenticated_client: Client) -> None:
     schedule = ScheduleClient(authenticated_client)
 
-    # 1. Create Group
+    # Create Group
     group_vo = await schedule.create_group("My Projects")
     assert isinstance(group_vo, AddScheduleTaskGroupVO)
     assert group_vo.task_list_id is not None
     group_id = int(group_vo.task_list_id)
 
-    # 2. List Groups
+    # List Groups
     groups = [g async for g in schedule.list_groups()]
     assert len(groups) == 1
-    # Find our group
     my_group = next((g for g in groups if str(g.task_list_id) == str(group_id)), None)
     assert my_group is not None
     assert my_group.title == "My Projects"
     assert isinstance(my_group, ScheduleTaskGroupItem)
 
-    # 3. Create Task
+    # Create Task
     task_vo = await schedule.create_task(
         group_id,
         "Finish Refactor",
@@ -59,16 +57,16 @@ async def test_schedule_flow(authenticated_client: Client) -> None:
     assert task_vo.task_id is not None
     task_id = int(task_vo.task_id)
 
-    # 4. List Tasks
+    # List Tasks
     tasks = [t async for t in schedule.list_tasks(group_id)]
     assert len(tasks) == 1
     task = tasks[0]
     assert str(task.task_id) == str(task_id)
     assert str(task.task_list_id) == str(group_id)
     assert task.title == "Finish Refactor"
-    assert task.is_reminder_on == BooleanEnum.NO  # Response is BooleanEnum
+    assert task.is_reminder_on == BooleanEnum.NO
 
-    # 5. Update Task
+    # Update Task
     update_vo = await schedule.update_task(
         task_id, title="Finish Refactor", status="completed", is_reminder_on=True
     )
@@ -81,12 +79,12 @@ async def test_schedule_flow(authenticated_client: Client) -> None:
     assert updated_task.status == "completed"
     assert updated_task.is_reminder_on == BooleanEnum.YES
 
-    # 6. Delete Task
+    # Delete Task
     await schedule.delete_task(task_id)
     tasks_after_delete = [t async for t in schedule.list_tasks(group_id)]
     assert len(tasks_after_delete) == 0
 
-    # 7. Delete Group
+    # Delete Group
     await schedule.delete_group(group_id)
     groups_after = [g async for g in schedule.list_groups()]
     assert len(groups_after) == 0
@@ -104,26 +102,21 @@ async def test_update_task_fields(authenticated_client: Client) -> None:
     assert task_vo.task_id is not None
     task_id = int(task_vo.task_id)
 
-    # Test 1: Partial Update - Title Only
     await schedule.update_task(task_id, title="Updated Title")
     tasks = [t async for t in schedule.list_tasks(group_id)]
     assert tasks[0].title == "Updated Title"
-    assert tasks[0].detail == "Original Detail"  # Should be unchanged
-    assert tasks[0].due_time == 1000  # Should be unchanged
+    assert tasks[0].detail == "Original Detail"
+    assert tasks[0].due_time == 1000
 
-    # Test 2: Update Detail (Title required)
     await schedule.update_task(task_id, title="Updated Title", detail="Updated Detail")
     tasks = [t async for t in schedule.list_tasks(group_id)]
-    assert tasks[0].title == "Updated Title"  # Should be unchanged
+    assert tasks[0].title == "Updated Title"
     assert tasks[0].detail == "Updated Detail"
 
-    # Test 3: Update Numeric Field (Zero handling?)
-    # due_time = 0
     await schedule.update_task(task_id, title="Updated Title", due_time=0)
     tasks = [t async for t in schedule.list_tasks(group_id)]
     assert tasks[0].due_time == 0
 
-    # Test 4: Update All Fields
     await schedule.update_task(
         task_id,
         title="Final Title",
@@ -142,5 +135,68 @@ async def test_update_task_fields(authenticated_client: Client) -> None:
     assert t.due_time == 9999
     assert t.is_reminder_on == BooleanEnum.YES
 
-    # Cleanup
     await schedule.delete_group(group_id)
+
+
+async def test_group_and_task_extended_routes(
+    authenticated_client: Client,
+) -> None:
+    schedule = ScheduleClient(authenticated_client)
+
+    # Create Group
+    group_vo = await schedule.create_group("Group Alpha")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    # Get Group Details
+    group_detail = await schedule.get_group(group_id)
+    assert group_detail.success is True
+    assert group_detail.title == "Group Alpha"
+    assert str(group_detail.task_list_id) == str(group_id)
+
+    # Update Group Title
+    up_res = await schedule.update_group(group_id, "Group Alpha Updated")
+    assert up_res.success is True
+    group_detail_up = await schedule.get_group(group_id)
+    assert group_detail_up.title == "Group Alpha Updated"
+
+    # Create Task & Get Task
+    task_vo = await schedule.create_task(group_id, "Task Beta", detail="Beta detail")
+    assert task_vo.task_id is not None
+    task_id = int(task_vo.task_id)
+
+    task_detail = await schedule.get_task(task_id)
+    assert task_detail.success is True
+    assert task_detail.title == "Task Beta"
+    assert task_detail.detail == "Beta detail"
+
+    # Clear Group Tasks
+    clear_res = await schedule.clear_group(group_id)
+    assert clear_res.success is True
+
+    tasks_after_clear = [t async for t in schedule.list_tasks(group_id)]
+    assert len(tasks_after_clear) == 0
+
+    await schedule.delete_group(group_id)
+
+
+async def test_sort_placeholders_return_501(authenticated_client: Client) -> None:
+    res_post = await authenticated_client.request(
+        "post", "/api/file/schedule/sort", json={}
+    )
+    assert res_post.status == 501
+
+    res_put = await authenticated_client.request(
+        "put", "/api/file/schedule/sort", json={}
+    )
+    assert res_put.status == 501
+
+    res_del = await authenticated_client.request(
+        "delete", "/api/file/schedule/sort/123"
+    )
+    assert res_del.status == 501
+
+    res_query = await authenticated_client.request(
+        "post", "/api/file/query/schedule/sort", json={}
+    )
+    assert res_query.status == 501

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -138,7 +138,7 @@ async def test_update_task_fields(authenticated_client: Client) -> None:
     await schedule.delete_group(group_id)
 
 
-async def test_group_and_task_extended_routes(
+async def test_schedule_group_and_task_routes(
     authenticated_client: Client,
 ) -> None:
     schedule = ScheduleClient(authenticated_client)
@@ -200,3 +200,53 @@ async def test_sort_placeholders_return_501(authenticated_client: Client) -> Non
         "post", "/api/file/query/schedule/sort", json={}
     )
     assert res_query.status == 501
+
+
+async def test_batch_update_task_list_transactional_rollback(
+    authenticated_client: Client,
+) -> None:
+    schedule = ScheduleClient(authenticated_client)
+
+    group_vo = await schedule.create_group("Batch Test Group")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    task1_vo = await schedule.create_task(group_id, "Task 1", detail="Detail 1")
+    task2_vo = await schedule.create_task(group_id, "Task 2", detail="Detail 2")
+    assert task1_vo.task_id is not None
+    assert task2_vo.task_id is not None
+
+    task1_id = int(task1_vo.task_id)
+    task2_id = int(task2_vo.task_id)
+
+    # Batch update where Task 1 is valid, but Task 2 exceeds MAX_TITLE_LENGTH
+    invalid_title = "A" * 300
+    batch_payload = {
+        "taskListId": str(group_id),
+        "updateScheduleTaskList": [
+            {
+                "taskId": str(task1_id),
+                "title": "Task 1 Updated",
+                "lastModified": 1000,
+            },
+            {
+                "taskId": str(task2_id),
+                "title": invalid_title,
+                "lastModified": 1000,
+            },
+        ],
+    }
+
+    res = await authenticated_client.request(
+        "put", "/api/file/schedule/task/list", json=batch_payload
+    )
+    assert res.status == 400
+
+    # Verify Task 1 was NOT updated due to atomic rollback
+    task1_detail = await schedule.get_task(task1_id)
+    assert task1_detail.title == "Task 1"
+
+    task2_detail = await schedule.get_task(task2_id)
+    assert task2_detail.title == "Task 2"
+
+    await schedule.delete_group(group_id)


### PR DESCRIPTION
## Description

This PR aligns the Supernote Schedule API routes and client library with the official Supernote OpenAPI specifications (`api-spec/paths/schedule.yaml`).

### Summary of Changes
- **Backend Services** (`supernote/server/services/schedule.py`): Added `get_group`, `update_group`, `clear_group`, and `get_task`.
- **Server Routes** (`supernote/server/routes/schedule.py`): Updated to exclusively expose official OpenAPI routes (`/api/file/schedule/group`, `/api/file/schedule/group/all`, `/api/file/schedule/group/{taskListId}`, `/api/file/schedule/group/clear`, `/api/file/schedule/task`, `/api/file/schedule/task/all`, `/api/file/schedule/task/{taskId}`, `/api/file/schedule/task/list`, and placeholder 501 handlers for sort endpoints). Refactored error handling to use `SupernoteError`.
- **Client SDK** (`supernote/client/schedule.py`): Updated `ScheduleClient` to invoke official `/api/file/schedule/...` endpoints and added client methods `get_group`, `update_group`, `clear_group`, and `get_task`.
- **Tests** (`tests/server/routes/test_schedule.py`): Added comprehensive integration tests.

### Verification
- `./script/lint` passed (0 errors).
- `./script/test` passed (533 tests passed).