### PR TITLE
feat(schedule): cascade delete contained tasks when deleting a group

### DIFF
--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -98,14 +98,19 @@ class ScheduleService:
             return True
 
     async def delete_group(self, user_id: int, group_id: int) -> bool:
-        """Delete a task group. Returns True if found and deleted."""
-        # For now, simplistic delete.
+        """Delete a task group and cascade delete all contained tasks."""
         async with self.session_manager.session() as session:
-            stmt = delete(ScheduleTaskGroupDO).where(
+            stmt_tasks = delete(ScheduleTaskDO).where(
+                ScheduleTaskDO.user_id == user_id,
+                ScheduleTaskDO.task_list_id == group_id,
+            )
+            await session.execute(stmt_tasks)
+
+            stmt_group = delete(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
                 ScheduleTaskGroupDO.task_list_id == group_id,
             )
-            result = await session.execute(stmt)
+            result = await session.execute(stmt_group)
             await session.commit()
             return bool(getattr(result, "rowcount", 0) > 0)
 

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -288,3 +288,26 @@ async def test_list_tasks_filtering_by_group_id(
     # Cleanup
     await schedule.delete_group(group_a_id)
     await schedule.delete_group(group_b_id)
+
+
+async def test_delete_group_cascades_contained_tasks(
+    authenticated_client: Client,
+) -> None:
+    schedule = ScheduleClient(authenticated_client)
+
+    group_vo = await schedule.create_group("Cascade Route Group")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    task1_vo = await schedule.create_task(group_id, "Subtask 1")
+    task2_vo = await schedule.create_task(group_id, "Subtask 2")
+    assert task1_vo.task_id is not None
+    assert task2_vo.task_id is not None
+
+    tasks_before = [t async for t in schedule.list_tasks(group_id)]
+    assert len(tasks_before) == 2
+
+    await schedule.delete_group(group_id)
+
+    tasks_after = [t async for t in schedule.list_tasks(group_id)]
+    assert len(tasks_after) == 0

--- a/tests/server/services/test_schedule.py
+++ b/tests/server/services/test_schedule.py
@@ -115,3 +115,28 @@ async def test_isolation(schedule_service: ScheduleService) -> None:
     # User 1 cannot delete User 2 group
     deleted = await schedule_service.delete_group(user1, g2.task_list_id)
     assert not deleted
+
+
+async def test_delete_group_cascades_contained_tasks(
+    schedule_service: ScheduleService,
+) -> None:
+    """Test that deleting a group automatically cascades and deletes all contained tasks."""
+    user_id = 777
+    group = await schedule_service.create_group(user_id, "Project X")
+
+    task1 = await schedule_service.create_task(user_id, group.task_list_id, "Subtask 1")
+    task2 = await schedule_service.create_task(user_id, group.task_list_id, "Subtask 2")
+    assert task1.task_id is not None
+    assert task2.task_id is not None
+
+    tasks_before = await schedule_service.list_tasks(user_id, group.task_list_id)
+    assert len(tasks_before) == 2
+
+    deleted = await schedule_service.delete_group(user_id, group.task_list_id)
+    assert deleted is True
+
+    groups_after = await schedule_service.list_groups(user_id)
+    assert not any(g.task_list_id == group.task_list_id for g in groups_after)
+
+    tasks_after = await schedule_service.list_tasks(user_id)
+    assert len(tasks_after) == 0


### PR DESCRIPTION
## Description

This PR adds automatic cascade deletion of child tasks when a task group is deleted in `ScheduleService.delete_group`.

### Summary of Changes
- **Service Layer** (`supernote/server/services/schedule.py`): Updated `delete_group` to delete all contained tasks (`ScheduleTaskDO`) with `task_list_id == group_id` before deleting the group (`ScheduleTaskGroupDO`) within the same database transaction.

### Verification
- `./script/lint` passed (0 errors).
- `./script/test` passed (533 passed, 1 skipped).