### PR TITLE
docs(skills): add visual UI testing flow using Playwright

### DIFF
--- a/.agent/skills/developer/SKILL.md
+++ b/.agent/skills/developer/SKILL.md
@@ -31,3 +31,42 @@ This skill teaches you how to interact with the Supernote codebase using standar
 - All scripts are located in the `script/` directory at the project root.
 - Scripts are designed to be run from the project root.
 - The scripts will automatically use `uv` if it is installed, otherwise they will fall back to standard Python tools.
+
+## Visual UI Testing Flow
+
+To visually inspect and verify Web UI components rendered in a headless browser:
+
+### 1. Install Prerequisites
+Ensure OS shared libraries and Python Playwright package are installed:
+```bash
+apt-get install -y libgbm1 libasound2 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libpango-1.0-0 libcairo2
+uv pip install playwright
+uv run playwright install chromium
+```
+
+### 2. Start Local Ephemeral Server
+Run `./script/server` as a background task (`WaitMsBeforeAsync: 3000`). This starts the local server at `http://127.0.0.1:8080` with default user `debug@example.com` / `password`.
+
+### 3. Capture & View Screenshot
+Execute Playwright script via `run_command`:
+```python
+import asyncio
+from playwright.async_api import async_playwright
+
+async def run():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page(viewport={"width": 1280, "height": 800})
+        await page.goto("http://127.0.0.1:8080")
+        await page.wait_for_timeout(1000)
+        await page.fill("input[type=email]", "debug@example.com")
+        await page.fill("input[type=password]", "password")
+        await page.click("button[type=submit]")
+        await page.wait_for_timeout(2000)
+        screenshot_path = "<artifacts_dir>/ui_screenshot.png"
+        await page.screenshot(path=screenshot_path)
+        await browser.close()
+
+asyncio.run(run())
+```
+Call `view_file` on the `.png` filepath to visually inspect and verify the rendered interface.


### PR DESCRIPTION
## Description

This PR documents the visual UI testing workflow in `.agent/skills/developer/SKILL.md`.

### Summary
- Added step-by-step instructions for running Playwright headless Chromium screenshots against `./script/server` to visually inspect and verify rendered web UI components.