### PR TITLE
fix(schedule): make title and last_modified optional in UpdateScheduleTaskDTO

### DIFF
--- a/supernote/models/schedule.py
+++ b/supernote/models/schedule.py
@@ -335,8 +335,10 @@ class UpdateScheduleTaskDTO(DataClassJSONMixin):
     """
 
     task_id: str = field(metadata=field_options(alias="taskId"))
-    title: str
-    last_modified: int = field(metadata=field_options(alias="lastModified"))
+    title: str | None = None
+    last_modified: int | None = field(
+        metadata=field_options(alias="lastModified"), default=None
+    )
     """Timestamp in milliseconds"""
 
     task_list_id: str | None = field(

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -135,6 +135,29 @@ async def test_update_task_fields(authenticated_client: Client) -> None:
     assert t.due_time == 9999
     assert t.is_reminder_on == BooleanEnum.YES
 
+
+async def test_update_task_partial_payload(authenticated_client: Client) -> None:
+    schedule = ScheduleClient(authenticated_client)
+    group_vo = await schedule.create_group("Partial Update Group")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    task_vo = await schedule.create_task(group_id, "Original Title")
+    assert task_vo.task_id is not None
+
+    # Perform raw PUT request omitting lastModified and title
+    resp = await authenticated_client.put(
+        "/api/file/schedule/task",
+        json={"taskId": task_vo.task_id, "status": "completed"},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["success"] is True
+
+    tasks = [t async for t in schedule.list_tasks(group_id)]
+    assert tasks[0].status == "completed"
+    assert tasks[0].title == "Original Title"
+
     await schedule.delete_group(group_id)
 
 


### PR DESCRIPTION
## Description

This PR fixes a `500 Internal Server Error` when clients issue partial task update requests via `PUT /api/file/schedule/task` (e.g. updating task status or detail notes without passing `title` or `lastModified`).

### Root Cause
In `supernote/models/schedule.py`, `UpdateScheduleTaskDTO` declared `title: str` and `last_modified: int` as mandatory required fields. When deserializing JSON payloads via Mashumaro, omitting these fields raised an uncaught `MissingField` exception, resulting in a 500 error response.

### Solution
- Updated `UpdateScheduleTaskDTO` in `supernote/models/schedule.py` to mark `title: str | None = None` and `last_modified: int | None = field(metadata=field_options(alias="lastModified"), default=None)`.
- Added unit test `test_update_task_partial_payload` in `tests/server/routes/test_schedule.py` verifying raw partial `PUT` update payloads.

### Verification
- `./script/lint`: Passed (0 errors).
- `uv run pytest tests/server/routes/test_schedule.py`: Passed (8 passed).