### PR TITLE
feat(server): set persistent default SUPERNOTE_JWT_SECRET in script/server

### DIFF
--- a/script/server
+++ b/script/server
@@ -7,6 +7,8 @@ cd "$(dirname "$0")/.."
 
 echo "==> Starting ephemeral server..."
 
+export SUPERNOTE_JWT_SECRET="${SUPERNOTE_JWT_SECRET:-supernote_dev_secret_key}"
+
 if command -v uv >/dev/null 2>&1; then
   uv run supernote serve --ephemeral "$@"
 else


### PR DESCRIPTION
## Description

This PR sets a default fallback `SUPERNOTE_JWT_SECRET` environment variable (`supernote_dev_secret_key`) in `script/server` for local development.

### Problem
Previously, `script/server` did not export a default `SUPERNOTE_JWT_SECRET`. On every local dev server restart, a random JWT secret was generated in memory, invalidating all active user sessions and requiring developers to log in again after every server restart.

### Solution
Export `SUPERNOTE_JWT_SECRET="${SUPERNOTE_JWT_SECRET:-supernote_dev_secret_key}"` in `script/server`.

### Verification
- Tested locally with `./script/server`: JWT tokens persist across server restarts.
- `./script/lint`: Passed (0 errors).