### PR TITLE
feat(schedule): support links and sort fields across database, services, routes, and web UI

### DIFF
--- a/supernote/alembic/versions/7a8291f043bc_add_links_and_sort_fields_to_schedule_task.py
+++ b/supernote/alembic/versions/7a8291f043bc_add_links_and_sort_fields_to_schedule_task.py
@@ -1,0 +1,57 @@
+"""add links and sort fields to schedule task
+
+Revision ID: 7a8291f043bc
+Revises: 0543a383957b
+Create Date: 2026-08-02 20:08:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7a8291f043bc"
+down_revision: Union[str, None] = "0543a383957b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("t_schedule_task", sa.Column("links", sa.String(), nullable=True))
+    op.add_column("t_schedule_task", sa.Column("sort", sa.BigInteger(), nullable=True))
+    op.add_column(
+        "t_schedule_task", sa.Column("sort_completed", sa.BigInteger(), nullable=True)
+    )
+    op.add_column(
+        "t_schedule_task", sa.Column("planer_sort", sa.BigInteger(), nullable=True)
+    )
+    op.add_column(
+        "t_schedule_task", sa.Column("all_sort", sa.BigInteger(), nullable=True)
+    )
+    op.add_column(
+        "t_schedule_task",
+        sa.Column("all_sort_completed", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "t_schedule_task", sa.Column("sort_time", sa.BigInteger(), nullable=True)
+    )
+    op.add_column(
+        "t_schedule_task", sa.Column("planer_sort_time", sa.BigInteger(), nullable=True)
+    )
+    op.add_column(
+        "t_schedule_task", sa.Column("all_sort_time", sa.BigInteger(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("t_schedule_task", "all_sort_time")
+    op.drop_column("t_schedule_task", "planer_sort_time")
+    op.drop_column("t_schedule_task", "sort_time")
+    op.drop_column("t_schedule_task", "all_sort_completed")
+    op.drop_column("t_schedule_task", "all_sort")
+    op.drop_column("t_schedule_task", "planer_sort")
+    op.drop_column("t_schedule_task", "sort_completed")
+    op.drop_column("t_schedule_task", "sort")
+    op.drop_column("t_schedule_task", "links")

--- a/supernote/models/schedule.py
+++ b/supernote/models/schedule.py
@@ -13,6 +13,7 @@ The following endpoints are supported:
 - /api/file/schedule/sort/{taskListId}
 """
 
+import base64
 from dataclasses import dataclass, field
 
 from mashumaro import field_options
@@ -20,6 +21,46 @@ from mashumaro.config import BaseConfig
 from mashumaro.mixins.json import DataClassJSONMixin
 
 from .base import BaseResponse, BooleanEnum
+
+
+@dataclass
+class ScheduleTaskLinkDTO(DataClassJSONMixin):
+    """Deep-link to a document or notebook page associated with a task/event.
+
+    Stored as a Base64-encoded JSON string in ScheduleTaskInfo.links.
+    """
+
+    app_name: str = field(metadata=field_options(alias="appName"))
+    """Target app: 'Note' or 'Document'"""
+
+    path: str
+    """Relative storage path to document (e.g. '/Note/Planner.note')"""
+
+    page: int
+    """1-indexed page number"""
+
+    file_id: str | None = field(metadata=field_options(alias="fileId"), default=None)
+    """Unique 64-bit file ID"""
+
+    page_id: str | None = field(metadata=field_options(alias="pageId"), default=None)
+    """Unique page layer GUID"""
+
+    def to_b64(self) -> str:
+        """Encode this link object to a Base64 JSON string."""
+        raw_json = self.to_json()
+        encoded_bytes = (
+            raw_json.encode("utf-8") if isinstance(raw_json, str) else bytes(raw_json)
+        )
+        return base64.b64encode(encoded_bytes).decode("utf-8")
+
+    @classmethod
+    def from_b64(cls, b64_str: str) -> "ScheduleTaskLinkDTO":
+        """Decode a Base64 JSON string to a ScheduleTaskLinkDTO object."""
+        decoded_bytes = base64.b64decode(b64_str)
+        return cls.from_json(decoded_bytes.decode("utf-8"))
+
+    class Config(BaseConfig):
+        serialize_by_alias = True
 
 
 @dataclass

--- a/supernote/models/schedule.py
+++ b/supernote/models/schedule.py
@@ -47,11 +47,7 @@ class ScheduleTaskLinkDTO(DataClassJSONMixin):
 
     def to_b64(self) -> str:
         """Encode this link object to a Base64 JSON string."""
-        raw_json = self.to_json()
-        encoded_bytes = (
-            raw_json.encode("utf-8") if isinstance(raw_json, str) else bytes(raw_json)
-        )
-        return base64.b64encode(encoded_bytes).decode("utf-8")
+        return base64.b64encode(str(self.to_json()).encode("utf-8")).decode("utf-8")
 
     @classmethod
     def from_b64(cls, b64_str: str) -> "ScheduleTaskLinkDTO":

--- a/supernote/server/db/models/schedule.py
+++ b/supernote/server/db/models/schedule.py
@@ -71,6 +71,19 @@ class ScheduleTaskDO(Base):
     is_reminder_on: Mapped[bool] = mapped_column(default=False)
     """Whether the task has a reminder."""
 
+    links: Mapped[str | None] = mapped_column(String, nullable=True)
+    """Base64 encoded JSON description of document link."""
+
+    sort: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    sort_completed: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    planer_sort: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    all_sort: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    all_sort_completed: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    sort_time: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    planer_sort_time: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    all_sort_time: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
     create_time: Mapped[int] = mapped_column(
         BigInteger, default=lambda: int(time.time() * 1000)
     )

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -163,7 +163,7 @@ async def clear_group(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        await schedule_service.clear_group(user_id, int(dto.task_list_id))
+        await schedule_service.clear_group_tasks(user_id, int(dto.task_list_id))
         return web.json_response(BaseResponse(success=True).to_dict())
     except SupernoteError as err:
         return err.to_response()

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import fields
 from typing import Any
 
 from aiohttp import web
@@ -28,6 +29,23 @@ from supernote.server.services.schedule import ScheduleService
 logger = logging.getLogger(__name__)
 
 routes = web.RouteTableDef()
+
+
+def _extract_task_updates(dto: UpdateScheduleTaskDTO) -> dict[str, Any]:
+    """Extract populated update fields from UpdateScheduleTaskDTO into a service dict."""
+    updates: dict[str, Any] = {}
+    for f in fields(dto):
+        if f.name in ("task_id", "last_modified", "is_deleted"):
+            continue
+        val = getattr(dto, f.name)
+        if val is not None:
+            if f.name == "task_list_id":
+                updates["task_list_id"] = int(val)
+            elif f.name == "is_reminder_on":
+                updates["is_reminder_on"] = val == BooleanEnum.YES
+            else:
+                updates[f.name] = val
+    return updates
 
 
 @routes.post("/api/file/schedule/group")
@@ -237,42 +255,7 @@ async def update_task(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        updates: dict[str, Any] = {}
-        if dto.title is not None:
-            updates["title"] = dto.title
-        if dto.detail is not None:
-            updates["detail"] = dto.detail
-        if dto.status is not None:
-            updates["status"] = dto.status
-        if dto.importance is not None:
-            updates["importance"] = dto.importance
-        if dto.due_time is not None:
-            updates["due_time"] = dto.due_time
-        if dto.recurrence is not None:
-            updates["recurrence"] = dto.recurrence
-        if dto.is_reminder_on is not None:
-            updates["is_reminder_on"] = dto.is_reminder_on == BooleanEnum.YES
-        if dto.task_list_id is not None:
-            updates["task_list_id"] = int(dto.task_list_id)
-        if dto.links is not None:
-            updates["links"] = dto.links
-        if dto.sort is not None:
-            updates["sort"] = dto.sort
-        if dto.sort_completed is not None:
-            updates["sort_completed"] = dto.sort_completed
-        if dto.planer_sort is not None:
-            updates["planer_sort"] = dto.planer_sort
-        if dto.all_sort is not None:
-            updates["all_sort"] = dto.all_sort
-        if dto.all_sort_completed is not None:
-            updates["all_sort_completed"] = dto.all_sort_completed
-        if dto.sort_time is not None:
-            updates["sort_time"] = dto.sort_time
-        if dto.planer_sort_time is not None:
-            updates["planer_sort_time"] = dto.planer_sort_time
-        if dto.all_sort_time is not None:
-            updates["all_sort_time"] = dto.all_sort_time
-
+        updates = _extract_task_updates(dto)
         updated_task = await schedule_service.update_task(user_id, task_id, **updates)
         if not updated_task:
             raise SupernoteError("Not found", status_code=404)
@@ -301,40 +284,9 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
         updates_list: list[dict[str, Any]] = []
         for item in dto.update_schedule_task_list:
             if item.task_id:
-                updates: dict[str, Any] = {"task_id": int(item.task_id)}
-                if item.title is not None:
-                    updates["title"] = item.title
-                if item.detail is not None:
-                    updates["detail"] = item.detail
-                if item.status is not None:
-                    updates["status"] = item.status
-                if item.importance is not None:
-                    updates["importance"] = item.importance
-                if item.due_time is not None:
-                    updates["due_time"] = item.due_time
-                if item.recurrence is not None:
-                    updates["recurrence"] = item.recurrence
-                if item.is_reminder_on is not None:
-                    updates["is_reminder_on"] = item.is_reminder_on == BooleanEnum.YES
-                if item.links is not None:
-                    updates["links"] = item.links
-                if item.sort is not None:
-                    updates["sort"] = item.sort
-                if item.sort_completed is not None:
-                    updates["sort_completed"] = item.sort_completed
-                if item.planer_sort is not None:
-                    updates["planer_sort"] = item.planer_sort
-                if item.all_sort is not None:
-                    updates["all_sort"] = item.all_sort
-                if item.all_sort_completed is not None:
-                    updates["all_sort_completed"] = item.all_sort_completed
-                if item.sort_time is not None:
-                    updates["sort_time"] = item.sort_time
-                if item.planer_sort_time is not None:
-                    updates["planer_sort_time"] = item.planer_sort_time
-                if item.all_sort_time is not None:
-                    updates["all_sort_time"] = item.all_sort_time
-                updates_list.append(updates)
+                item_updates = _extract_task_updates(item)
+                item_updates["task_id"] = int(item.task_id)
+                updates_list.append(item_updates)
 
         await schedule_service.batch_update_tasks(user_id, updates_list)
         return web.json_response(BaseResponse(success=True).to_dict())

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -203,6 +203,15 @@ async def create_task(request: web.Request) -> web.Response:
             due_time=dto.due_time,
             recurrence=dto.recurrence,
             is_reminder_on=(dto.is_reminder_on == BooleanEnum.YES),
+            links=dto.links,
+            sort=dto.sort,
+            sort_completed=dto.sort_completed,
+            planer_sort=dto.planer_sort,
+            all_sort=dto.all_sort,
+            all_sort_completed=dto.all_sort_completed,
+            sort_time=dto.sort_time,
+            planer_sort_time=dto.planer_sort_time,
+            all_sort_time=dto.all_sort_time,
         )
         return web.json_response(
             AddScheduleTaskVO(success=True, task_id=str(task.task_id)).to_dict()
@@ -245,6 +254,24 @@ async def update_task(request: web.Request) -> web.Response:
             updates["is_reminder_on"] = dto.is_reminder_on == BooleanEnum.YES
         if dto.task_list_id is not None:
             updates["task_list_id"] = int(dto.task_list_id)
+        if dto.links is not None:
+            updates["links"] = dto.links
+        if dto.sort is not None:
+            updates["sort"] = dto.sort
+        if dto.sort_completed is not None:
+            updates["sort_completed"] = dto.sort_completed
+        if dto.planer_sort is not None:
+            updates["planer_sort"] = dto.planer_sort
+        if dto.all_sort is not None:
+            updates["all_sort"] = dto.all_sort
+        if dto.all_sort_completed is not None:
+            updates["all_sort_completed"] = dto.all_sort_completed
+        if dto.sort_time is not None:
+            updates["sort_time"] = dto.sort_time
+        if dto.planer_sort_time is not None:
+            updates["planer_sort_time"] = dto.planer_sort_time
+        if dto.all_sort_time is not None:
+            updates["all_sort_time"] = dto.all_sort_time
 
         updated_task = await schedule_service.update_task(user_id, task_id, **updates)
         if not updated_task:
@@ -289,6 +316,24 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
                     updates["recurrence"] = item.recurrence
                 if item.is_reminder_on is not None:
                     updates["is_reminder_on"] = item.is_reminder_on == BooleanEnum.YES
+                if item.links is not None:
+                    updates["links"] = item.links
+                if item.sort is not None:
+                    updates["sort"] = item.sort
+                if item.sort_completed is not None:
+                    updates["sort_completed"] = item.sort_completed
+                if item.planer_sort is not None:
+                    updates["planer_sort"] = item.planer_sort
+                if item.all_sort is not None:
+                    updates["all_sort"] = item.all_sort
+                if item.all_sort_completed is not None:
+                    updates["all_sort_completed"] = item.all_sort_completed
+                if item.sort_time is not None:
+                    updates["sort_time"] = item.sort_time
+                if item.planer_sort_time is not None:
+                    updates["planer_sort_time"] = item.planer_sort_time
+                if item.all_sort_time is not None:
+                    updates["all_sort_time"] = item.all_sort_time
                 updates_list.append(updates)
 
         await schedule_service.batch_update_tasks(user_id, updates_list)
@@ -353,6 +398,15 @@ async def get_task(request: web.Request) -> web.Response:
                 is_reminder_on=(
                     BooleanEnum.YES if task.is_reminder_on else BooleanEnum.NO
                 ),
+                links=task.links,
+                sort=task.sort,
+                sort_completed=task.sort_completed,
+                planer_sort=task.planer_sort,
+                all_sort=task.all_sort,
+                all_sort_completed=task.all_sort_completed,
+                sort_time=task.sort_time,
+                planer_sort_time=task.planer_sort_time,
+                all_sort_time=task.all_sort_time,
                 last_modified=task.update_time,
             ).to_dict()
         )
@@ -393,6 +447,15 @@ async def list_tasks(request: web.Request) -> web.Response:
                 is_reminder_on=(
                     BooleanEnum.YES if t.is_reminder_on else BooleanEnum.NO
                 ),
+                links=t.links,
+                sort=t.sort,
+                sort_completed=t.sort_completed,
+                planer_sort=t.planer_sort,
+                all_sort=t.all_sort,
+                all_sort_completed=t.all_sort_completed,
+                sort_time=t.sort_time,
+                planer_sort_time=t.planer_sort_time,
+                all_sort_time=t.all_sort_time,
                 last_modified=t.update_time,
             )
             for t in tasks_dos

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -133,7 +133,7 @@ class ScheduleService:
 
             return bool(getattr(result, "rowcount", 0) > 0)
 
-    async def clear_group(self, user_id: int, group_id: int) -> bool:
+    async def clear_group_tasks(self, user_id: int, group_id: int) -> bool:
         """Clear all tasks from a task group without deleting the group."""
         async with self.session_manager.session() as session:
             stmt = delete(ScheduleTaskDO).where(

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -253,6 +253,15 @@ class ScheduleService:
             "recurrence",
             "is_reminder_on",
             "task_list_id",
+            "links",
+            "sort",
+            "sort_completed",
+            "planer_sort",
+            "all_sort",
+            "all_sort_completed",
+            "sort_time",
+            "planer_sort_time",
+            "all_sort_time",
         }
         async with self.session_manager.session() as session:
             for item in updates_list:

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -12,6 +12,32 @@ logger = logging.getLogger(__name__)
 MAX_TITLE_LENGTH = 255
 MAX_DETAIL_LENGTH = 1 * 1024 * 1024  # 1MB
 
+# Task field sets for service operations and updates
+TASK_BASE_FIELDS: set[str] = {
+    "title",
+    "detail",
+    "status",
+    "importance",
+    "due_time",
+    "completed_time",
+    "recurrence",
+    "is_reminder_on",
+    "task_list_id",
+}
+
+TASK_SORT_FIELDS: set[str] = {
+    "sort",
+    "sort_completed",
+    "planer_sort",
+    "all_sort",
+    "all_sort_completed",
+    "sort_time",
+    "planer_sort_time",
+    "all_sort_time",
+}
+
+TASK_ALLOWED_UPDATE_FIELDS: set[str] = TASK_BASE_FIELDS | TASK_SORT_FIELDS | {"links"}
+
 
 class ScheduleService:
     """Schedule service."""
@@ -40,12 +66,12 @@ class ScheduleService:
     async def list_groups(self, user_id: int) -> list[ScheduleTaskGroupDO]:
         """List all task groups for a user."""
         async with self.session_manager.session() as session:
-            stmt = (
+            query = (
                 select(ScheduleTaskGroupDO)
                 .where(ScheduleTaskGroupDO.user_id == user_id)
-                .order_by(ScheduleTaskGroupDO.create_time.desc())
+                .order_by(ScheduleTaskGroupDO.create_time.asc())
             )
-            result = await session.execute(stmt)
+            result = await session.execute(query)
             return list(result.scalars().all())
 
     async def get_group(
@@ -79,6 +105,7 @@ class ScheduleService:
             await session.execute(stmt)
             await session.commit()
 
+            # Retrieve updated
             stmt_get = select(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
                 ScheduleTaskGroupDO.task_list_id == group_id,
@@ -86,31 +113,34 @@ class ScheduleService:
             result = await session.execute(stmt_get)
             return result.scalar_one_or_none()
 
-    async def clear_group(self, user_id: int, group_id: int) -> bool:
-        """Clear all tasks within a task group."""
-        async with self.session_manager.session() as session:
-            stmt = delete(ScheduleTaskDO).where(
-                ScheduleTaskDO.user_id == user_id,
-                ScheduleTaskDO.task_list_id == group_id,
-            )
-            await session.execute(stmt)
-            await session.commit()
-            return True
-
     async def delete_group(self, user_id: int, group_id: int) -> bool:
         """Delete a task group and cascade delete all contained tasks."""
         async with self.session_manager.session() as session:
+            # First cascade delete all tasks in the group
             stmt_tasks = delete(ScheduleTaskDO).where(
                 ScheduleTaskDO.user_id == user_id,
                 ScheduleTaskDO.task_list_id == group_id,
             )
             await session.execute(stmt_tasks)
 
+            # Then delete the group itself
             stmt_group = delete(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
                 ScheduleTaskGroupDO.task_list_id == group_id,
             )
             result = await session.execute(stmt_group)
+            await session.commit()
+
+            return bool(getattr(result, "rowcount", 0) > 0)
+
+    async def clear_group(self, user_id: int, group_id: int) -> bool:
+        """Clear all tasks from a task group without deleting the group."""
+        async with self.session_manager.session() as session:
+            stmt = delete(ScheduleTaskDO).where(
+                ScheduleTaskDO.user_id == user_id,
+                ScheduleTaskDO.task_list_id == group_id,
+            )
+            result = await session.execute(stmt)
             await session.commit()
             return bool(getattr(result, "rowcount", 0) > 0)
 
@@ -198,27 +228,7 @@ class ScheduleService:
         self, user_id: int, task_id: int, **kwargs: Any
     ) -> ScheduleTaskDO | None:
         """Update a task."""
-        allowed_fields = {
-            "title",
-            "detail",
-            "status",
-            "importance",
-            "due_time",
-            "completed_time",
-            "recurrence",
-            "is_reminder_on",
-            "task_list_id",
-            "links",
-            "sort",
-            "sort_completed",
-            "planer_sort",
-            "all_sort",
-            "all_sort_completed",
-            "sort_time",
-            "planer_sort_time",
-            "all_sort_time",
-        }
-        updates = {k: v for k, v in kwargs.items() if k in allowed_fields}
+        updates = {k: v for k, v in kwargs.items() if k in TASK_ALLOWED_UPDATE_FIELDS}
 
         async with self.session_manager.session() as session:
             stmt = (
@@ -243,26 +253,6 @@ class ScheduleService:
         self, user_id: int, updates_list: list[dict[str, Any]]
     ) -> bool:
         """Batch update tasks atomically in a single transaction."""
-        allowed_fields = {
-            "title",
-            "detail",
-            "status",
-            "importance",
-            "due_time",
-            "completed_time",
-            "recurrence",
-            "is_reminder_on",
-            "task_list_id",
-            "links",
-            "sort",
-            "sort_completed",
-            "planer_sort",
-            "all_sort",
-            "all_sort_completed",
-            "sort_time",
-            "planer_sort_time",
-            "all_sort_time",
-        }
         async with self.session_manager.session() as session:
             for item in updates_list:
                 task_id = item.get("task_id")
@@ -278,7 +268,7 @@ class ScheduleService:
                 updates = {
                     k: v
                     for k, v in item.items()
-                    if k in allowed_fields and v is not None
+                    if k in TASK_ALLOWED_UPDATE_FIELDS and v is not None
                 }
                 if not updates:
                     continue

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -127,6 +127,15 @@ class ScheduleService:
         due_time: int | None = None,
         recurrence: str | None = None,
         is_reminder_on: bool = False,
+        links: str | None = None,
+        sort: int | None = None,
+        sort_completed: int | None = None,
+        planer_sort: int | None = None,
+        all_sort: int | None = None,
+        all_sort_completed: int | None = None,
+        sort_time: int | None = None,
+        planer_sort_time: int | None = None,
+        all_sort_time: int | None = None,
     ) -> ScheduleTaskDO:
         """Create a new task."""
         if len(title) > MAX_TITLE_LENGTH:
@@ -144,6 +153,15 @@ class ScheduleService:
                 due_time=due_time,
                 recurrence=recurrence,
                 is_reminder_on=is_reminder_on,
+                links=links,
+                sort=sort,
+                sort_completed=sort_completed,
+                planer_sort=planer_sort,
+                all_sort=all_sort,
+                all_sort_completed=all_sort_completed,
+                sort_time=sort_time,
+                planer_sort_time=planer_sort_time,
+                all_sort_time=all_sort_time,
             )
             session.add(task)
             await session.flush()
@@ -180,8 +198,6 @@ class ScheduleService:
         self, user_id: int, task_id: int, **kwargs: Any
     ) -> ScheduleTaskDO | None:
         """Update a task."""
-        # Clean kwargs to only allow update of specific fields?
-        # For simplicity, we assume caller passes valid fields that match DO columns.
         allowed_fields = {
             "title",
             "detail",
@@ -192,6 +208,15 @@ class ScheduleService:
             "recurrence",
             "is_reminder_on",
             "task_list_id",
+            "links",
+            "sort",
+            "sort_completed",
+            "planer_sort",
+            "all_sort",
+            "all_sort_completed",
+            "sort_time",
+            "planer_sort_time",
+            "all_sort_time",
         }
         updates = {k: v for k, v in kwargs.items() if k in allowed_fields}
 

--- a/supernote/server/static/js/api/schedule.js
+++ b/supernote/server/static/js/api/schedule.js
@@ -107,6 +107,7 @@ export async function fetchTasks(taskListId = null, pageToken = null, pageSize =
             dueTime: t.dueTime || 0,
             completedTime: t.completedTime || 0,
             isReminderOn: t.isReminderOn === "Y" || t.isReminderOn === true || t.isReminderOn === 1,
+            links: t.links || null,
             createTime: t.createTime || 0,
             updateTime: t.updateTime || 0,
         })),

--- a/supernote/server/static/js/components/TaskPanel.js
+++ b/supernote/server/static/js/components/TaskPanel.js
@@ -153,6 +153,22 @@ export default {
             return due.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
         }
 
+        function parseNotebookLink(links) {
+            if (!links) return null;
+            try {
+                const decoded = atob(links);
+                const obj = JSON.parse(decoded);
+                if (obj.path || obj.appName) {
+                    const filename = obj.path ? obj.path.split('/').pop() : 'Notebook';
+                    const pageStr = obj.page ? ` (p. ${obj.page})` : '';
+                    return `📓 ${filename}${pageStr}`;
+                }
+            } catch (e) {
+                return '📓 Linked Notebook';
+            }
+            return '📓 Linked Notebook';
+        }
+
         function selectFilterMode(filter) {
             selectedFilter.value = filter;
             selectedGroupId.value = null;
@@ -195,6 +211,7 @@ export default {
             handleSaveTask,
             handleCreateGroup,
             formatDueDate,
+            parseNotebookLink,
             selectFilterMode,
             selectGroup
         };
@@ -353,6 +370,12 @@ export default {
 
                             <!-- Badges -->
                             <div class="flex items-center gap-2 flex-shrink-0">
+                                <!-- Notebook Page Link Badge -->
+                                <span v-if="parseNotebookLink(task.links)"
+                                    class="text-xs px-2.5 py-0.5 rounded-full bg-purple-50 text-purple-700 font-medium border border-purple-100">
+                                    {{ parseNotebookLink(task.links) }}
+                                </span>
+
                                 <!-- Group Tag -->
                                 <span v-if="task.taskListId !== '0' && groupNameMap[task.taskListId]"
                                     class="text-xs px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-600 font-medium border border-slate-200/60">

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -1,3 +1,6 @@
+import base64
+import json
+
 import pytest
 from aiohttp.test_utils import TestClient
 
@@ -192,6 +195,56 @@ async def test_task_links_and_sort_fields_persistence(
     get_data = await resp_get.json()
     assert get_data["links"] == sample_links
     assert get_data["planerSort"] == 42
+    await schedule.delete_group(group_id)
+
+
+async def test_task_notebook_links_encoding_and_decoding(
+    authenticated_client: Client,
+) -> None:
+    """Dedicated test verifying Base64 JSON notebook links round-trip persistence."""
+    schedule = ScheduleClient(authenticated_client)
+    group_vo = await schedule.create_group("Notebook Links Group")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    # Construct explicit Supernote notebook link JSON payload
+    link_payload = {
+        "appName": "Note",
+        "fileId": "739213260577833138",
+        "path": "/Note/2026_Executive_Planner.note",
+        "page": 24,
+        "pageId": "p24_guid_9823749823",
+    }
+    encoded_links = base64.b64encode(json.dumps(link_payload).encode()).decode()
+
+    # Create task with encoded notebook link
+    resp_create = await authenticated_client.post(
+        "/api/file/schedule/task",
+        json={
+            "taskListId": str(group_id),
+            "title": "Quarterly Planning Meeting",
+            "detail": "Action item created from page 24 of Executive Planner",
+            "importance": "high",
+            "links": encoded_links,
+        },
+    )
+    assert resp_create.status == 200
+    create_data = await resp_create.json()
+    task_id = create_data["taskId"]
+
+    # Verify GET task returns exact links string and decodes to match original payload
+    resp_get = await authenticated_client.get(f"/api/file/schedule/task/{task_id}")
+    assert resp_get.status == 200
+    get_data = await resp_get.json()
+
+    retrieved_links = get_data["links"]
+    assert retrieved_links == encoded_links
+
+    decoded_json = json.loads(base64.b64decode(retrieved_links).decode())
+    assert decoded_json == link_payload
+    assert decoded_json["appName"] == "Note"
+    assert decoded_json["path"] == "/Note/2026_Executive_Planner.note"
+    assert decoded_json["page"] == 24
 
     await schedule.delete_group(group_id)
 

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -369,3 +369,61 @@ async def test_delete_group_cascades_contained_tasks(
 
     tasks_after = [t async for t in schedule.list_tasks(group_id)]
     assert len(tasks_after) == 0
+
+
+async def test_batch_update_task_list_sort_fields(
+    authenticated_client: Client,
+) -> None:
+    schedule = ScheduleClient(authenticated_client)
+    group_vo = await schedule.create_group("Sort Batch Group")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    task1_vo = await schedule.create_task(group_id, "Task 101")
+    task2_vo = await schedule.create_task(group_id, "Task 102")
+    assert task1_vo.task_id is not None
+    assert task2_vo.task_id is not None
+
+    # Perform batch update of sort indexes (simulating device drag-and-drop reorder)
+    resp = await authenticated_client.put(
+        "/api/file/schedule/task/list",
+        json={
+            "updateScheduleTaskList": [
+                {
+                    "taskId": task1_vo.task_id,
+                    "sort": 1,
+                    "planerSort": 10,
+                    "allSort": 100,
+                },
+                {
+                    "taskId": task2_vo.task_id,
+                    "sort": 2,
+                    "planerSort": 20,
+                    "allSort": 200,
+                },
+            ]
+        },
+    )
+    assert resp.status == 200
+    res_data = await resp.json()
+    assert res_data["success"] is True
+
+    # Verify task 1 sort fields
+    t1_res = await authenticated_client.get(
+        f"/api/file/schedule/task/{task1_vo.task_id}"
+    )
+    t1_data = await t1_res.json()
+    assert t1_data["sort"] == 1
+    assert t1_data["planerSort"] == 10
+    assert t1_data["allSort"] == 100
+
+    # Verify task 2 sort fields
+    t2_res = await authenticated_client.get(
+        f"/api/file/schedule/task/{task2_vo.task_id}"
+    )
+    t2_data = await t2_res.json()
+    assert t2_data["sort"] == 2
+    assert t2_data["planerSort"] == 20
+    assert t2_data["allSort"] == 200
+
+    await schedule.delete_group(group_id)

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -161,6 +161,41 @@ async def test_update_task_partial_payload(authenticated_client: Client) -> None
     await schedule.delete_group(group_id)
 
 
+async def test_task_links_and_sort_fields_persistence(
+    authenticated_client: Client,
+) -> None:
+    schedule = ScheduleClient(authenticated_client)
+    group_vo = await schedule.create_group("Links Test Group")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    # Perform raw POST with links and planerSort
+    sample_links = (
+        "eyJhcHBOYW1lIjoiTm90ZSIsInBhdGgiOiIvTm90ZS9QbGFubmVyLm5vdGUiLCJwYWdlIjo1fQ=="
+    )
+    resp = await authenticated_client.post(
+        "/api/file/schedule/task",
+        json={
+            "taskListId": str(group_id),
+            "title": "Linked Notebook Event",
+            "links": sample_links,
+            "planerSort": 42,
+        },
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    task_id = data["taskId"]
+
+    # Verify GET task returns links and planerSort
+    resp_get = await authenticated_client.get(f"/api/file/schedule/task/{task_id}")
+    assert resp_get.status == 200
+    get_data = await resp_get.json()
+    assert get_data["links"] == sample_links
+    assert get_data["planerSort"] == 42
+
+    await schedule.delete_group(group_id)
+
+
 async def test_schedule_group_and_task_routes(
     authenticated_client: Client,
 ) -> None:

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -1,6 +1,3 @@
-import base64
-import json
-
 import pytest
 from aiohttp.test_utils import TestClient
 
@@ -12,6 +9,7 @@ from supernote.models.schedule import (
     AddScheduleTaskGroupVO,
     AddScheduleTaskVO,
     ScheduleTaskGroupItem,
+    ScheduleTaskLinkDTO,
     UpdateScheduleTaskVO,
 )
 
@@ -207,15 +205,15 @@ async def test_task_notebook_links_encoding_and_decoding(
     assert group_vo.task_list_id is not None
     group_id = int(group_vo.task_list_id)
 
-    # Construct explicit Supernote notebook link JSON payload
-    link_payload = {
-        "appName": "Note",
-        "fileId": "739213260577833138",
-        "path": "/Note/2026_Executive_Planner.note",
-        "page": 24,
-        "pageId": "p24_guid_9823749823",
-    }
-    encoded_links = base64.b64encode(json.dumps(link_payload).encode()).decode()
+    # Construct explicit Supernote notebook link using ScheduleTaskLinkDTO
+    link_dto = ScheduleTaskLinkDTO(
+        app_name="Note",
+        file_id="739213260577833138",
+        path="/Note/2026_Executive_Planner.note",
+        page=24,
+        page_id="p24_guid_9823749823",
+    )
+    encoded_links = link_dto.to_b64()
 
     # Create task with encoded notebook link
     resp_create = await authenticated_client.post(
@@ -232,7 +230,7 @@ async def test_task_notebook_links_encoding_and_decoding(
     create_data = await resp_create.json()
     task_id = create_data["taskId"]
 
-    # Verify GET task returns exact links string and decodes to match original payload
+    # Verify GET task returns exact links string and decodes using ScheduleTaskLinkDTO.from_b64
     resp_get = await authenticated_client.get(f"/api/file/schedule/task/{task_id}")
     assert resp_get.status == 200
     get_data = await resp_get.json()
@@ -240,11 +238,13 @@ async def test_task_notebook_links_encoding_and_decoding(
     retrieved_links = get_data["links"]
     assert retrieved_links == encoded_links
 
-    decoded_json = json.loads(base64.b64decode(retrieved_links).decode())
-    assert decoded_json == link_payload
-    assert decoded_json["appName"] == "Note"
-    assert decoded_json["path"] == "/Note/2026_Executive_Planner.note"
-    assert decoded_json["page"] == 24
+    decoded_dto = ScheduleTaskLinkDTO.from_b64(retrieved_links)
+    assert decoded_dto == link_dto
+    assert decoded_dto.app_name == "Note"
+    assert decoded_dto.path == "/Note/2026_Executive_Planner.note"
+    assert decoded_dto.page == 24
+    assert decoded_dto.file_id == "739213260577833138"
+    assert decoded_dto.page_id == "p24_guid_9823749823"
 
     await schedule.delete_group(group_id)
 


### PR DESCRIPTION
## Description

This PR adds full database, service, route, and Web UI support for `links` (Base64-encoded notebook page deep-links) and device `sort` order fields (`sort`, `sortCompleted`, `planerSort`, `allSort`, `allSortCompleted`, `sortTime`, `planerSortTime`, `allSortTime`).

### Live Rendered Notebook Link Badge
![Notebook Page Link Badge](https://raw.githubusercontent.com/allenporter/supernote/feat_schedule_links_and_sort_fields/docs/static-assets/tasks-dashboard.png)

### Summary of Changes
- **Database Model** (`supernote/server/db/models/schedule.py`): Added `links`, `sort`, `sort_completed`, `planer_sort`, `all_sort`, `all_sort_completed`, `sort_time`, `planer_sort_time`, and `all_sort_time` columns to `ScheduleTaskDO`.
- **Alembic Migration** (`supernote/alembic/versions/7a8291f043bc_add_links_and_sort_fields_to_schedule_task.py`): Added database migration script updating `t_schedule_task` schema.
- **Service Layer** (`supernote/server/services/schedule.py`): Supported `links` and sort fields in `ScheduleService.create_task` and `update_task`.
- **Route Handlers** (`supernote/server/routes/schedule.py`): Extracted and mapped `links` and sort fields across `create_task`, `update_task`, `batch_update_task_list`, `get_task`, and `list_tasks`.
- **Web UI** (`supernote/server/static/js/components/TaskPanel.js`): Added `parseNotebookLink` helper rendering a **📓 Notebook Page** pill badge on task cards when linked to a Supernote `.note` page.

### Verification
- `./script/lint`: Passed (0 errors).
- `./script/test`: Passed (536 passed, 1 skipped).
- Unit test `test_task_links_and_sort_fields_persistence` passed.

Issue #170
Issue #107