### PR TITLE
fix(web): preserve 64-bit Snowflake fileId precision in API calls and handle unescaped newlines

### DIFF
--- a/supernote/server/services/processor_modules/summary.py
+++ b/supernote/server/services/processor_modules/summary.py
@@ -226,7 +226,7 @@ class SummaryModule(ProcessorModule):
 
                 for seg in segments_data:
                     date_range = seg.get("date_range", "Unknown Date")
-                    text = seg.get("summary", "")
+                    text = seg.get("summary", "").replace("\\n", "\n")
                     dates = seg.get("extracted_dates", [])
                     page_refs = seg.get("page_refs", [])
 

--- a/supernote/server/static/js/api/client.js
+++ b/supernote/server/static/js/api/client.js
@@ -179,7 +179,7 @@ export async function fetchTranscript(fileId) {
             'Content-Type': 'application/json',
             'x-access-token': currentToken
         },
-        body: JSON.stringify({ fileId: parseInt(fileId) })
+        body: JSON.stringify({ fileId: String(fileId) })
     });
 
     if (!response.ok) return '';
@@ -203,7 +203,7 @@ export async function fetchSummaries(fileId) {
             'x-access-token': currentToken
         },
         // Extension endpoint expects { fileId: ... }
-        body: JSON.stringify({ fileId: fileId })
+        body: JSON.stringify({ fileId: String(fileId) })
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Description
- Updated `fetchTranscript` and `fetchSummaries` in `client.js` to pass `fileId` as `String(fileId)`, preventing JS `parseInt` precision loss on 64-bit Snowflake notebook IDs.
- Unescaped literal `\\n` sequences in Gemini summary JSON text in `summary.py` so multiline lists and bullet points render cleanly with linebreaks.