### PR TITLE
perf(server): lazy import google-genai

### DIFF
--- a/supernote/server/app.py
+++ b/supernote/server/app.py
@@ -17,8 +17,6 @@ from yarl import URL
 
 from supernote.models.base import create_error_response
 from supernote.server.db.migrations import run_migrations
-from supernote.server.mcp.auth import create_auth_app
-from supernote.server.mcp.server import create_mcp_server, run_server, set_services
 from supernote.server.utils.auth_utils import get_token_from_request
 
 from .config import ServerConfig
@@ -421,6 +419,16 @@ def create_app(config: ServerConfig) -> web.Application:
 
     # Register Middlewares
     async def on_startup_handler(app: web.Application) -> None:
+        # Deferred: the `mcp` package is a heavy import, so it's only loaded
+        # once the server actually starts up and needs to mount the MCP
+        # Authorization Server / MCP tool server.
+        from supernote.server.mcp.auth import create_auth_app  # noqa: PLC0415
+        from supernote.server.mcp.server import (  # noqa: PLC0415
+            create_mcp_server,
+            run_server,
+            set_services,
+        )
+
         # Configure proxy middleware based on config
         if config.proxy_mode == "strict":
             # XForwardedStrict requires explicit trusted proxy IPs

--- a/supernote/server/app.py
+++ b/supernote/server/app.py
@@ -17,6 +17,8 @@ from yarl import URL
 
 from supernote.models.base import create_error_response
 from supernote.server.db.migrations import run_migrations
+from supernote.server.mcp.auth import create_auth_app
+from supernote.server.mcp.server import create_mcp_server, run_server, set_services
 from supernote.server.utils.auth_utils import get_token_from_request
 
 from .config import ServerConfig
@@ -419,16 +421,6 @@ def create_app(config: ServerConfig) -> web.Application:
 
     # Register Middlewares
     async def on_startup_handler(app: web.Application) -> None:
-        # Deferred: the `mcp` package is a heavy import, so it's only loaded
-        # once the server actually starts up and needs to mount the MCP
-        # Authorization Server / MCP tool server.
-        from supernote.server.mcp.auth import create_auth_app  # noqa: PLC0415
-        from supernote.server.mcp.server import (  # noqa: PLC0415
-            create_mcp_server,
-            run_server,
-            set_services,
-        )
-
         # Configure proxy middleware based on config
         if config.proxy_mode == "strict":
             # XForwardedStrict requires explicit trusted proxy IPs

--- a/supernote/server/services/gemini.py
+++ b/supernote/server/services/gemini.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import logging
 import time
@@ -20,7 +18,7 @@ class GeminiService:
     def __init__(self, api_key: str | None, max_concurrency: int = 5) -> None:
         self.api_key = api_key
         self.max_concurrency = max_concurrency
-        self._client: genai.Client | None = None
+        self._client: "genai.Client | None" = None
         self._semaphore: asyncio.Semaphore | None = None
         if self.api_key:
             # Deferred: google-genai is a heavy import (pulls in ~300
@@ -46,8 +44,8 @@ class GeminiService:
         self,
         model: str,
         contents: Any,
-        config: types.GenerateContentConfigOrDict | None = None,
-    ) -> types.GenerateContentResponse:
+        config: "types.GenerateContentConfigOrDict | None" = None,
+    ) -> "types.GenerateContentResponse":
         """Asynchronously generate content using the Gemini API."""
         if self._client is None:
             raise ValueError("Gemini API key not configured")
@@ -77,8 +75,8 @@ class GeminiService:
         self,
         model: str,
         contents: Any,
-        config: types.EmbedContentConfigOrDict | None = None,
-    ) -> types.EmbedContentResponse:
+        config: "types.EmbedContentConfigOrDict | None" = None,
+    ) -> "types.EmbedContentResponse":
         """Asynchronously generate embeddings using the Gemini API."""
         if self._client is None:
             raise ValueError("Gemini API key not configured")

--- a/supernote/server/services/gemini.py
+++ b/supernote/server/services/gemini.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import time
-from typing import Any
-
-from google import genai
-from google.genai import types
+from typing import TYPE_CHECKING, Any
 
 from supernote.server.metrics import GEMINI_API_CALLS_TOTAL, GEMINI_API_DURATION_SECONDS
+
+if TYPE_CHECKING:
+    from google import genai
+    from google.genai import types
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +23,11 @@ class GeminiService:
         self._client: genai.Client | None = None
         self._semaphore: asyncio.Semaphore | None = None
         if self.api_key:
+            # Deferred: google-genai is a heavy import (pulls in ~300
+            # transitive modules), so only pay for it when an API key is
+            # actually configured.
+            from google import genai  # noqa: PLC0415
+
             self._client = genai.Client(
                 api_key=self.api_key, http_options={"api_version": "v1alpha"}
             )

--- a/supernote/server/services/processor_modules/gemini_ocr.py
+++ b/supernote/server/services/processor_modules/gemini_ocr.py
@@ -1,7 +1,5 @@
 import logging
 
-from google.genai import types
-
 from supernote.server.config import ServerConfig
 from supernote.server.constants import CACHE_BUCKET
 from supernote.server.db.models.file import UserFileDO
@@ -81,6 +79,9 @@ class GeminiOcrModule(ProcessorModule):
         if page_id is None:
             logger.error(f"Page ID required for OCR processing of file {file_id}")
             return
+
+        # Deferred: google-genai is only needed once OCR actually runs.
+        from google.genai import types  # noqa: PLC0415
 
         # Get PNG Content
         png_path = get_page_png_path(file_id, page_id)

--- a/supernote/server/utils/gemini_content.py
+++ b/supernote/server/utils/gemini_content.py
@@ -1,12 +1,16 @@
 """Library for preparing Gemini Content requests."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
-
-from google.genai import types
+from typing import TYPE_CHECKING
 
 from .note_content import format_page_metadata
 from .prompt_loader import PROMPT_LOADER, PromptId
+
+if TYPE_CHECKING:
+    from google.genai import types
 
 
 @dataclass
@@ -27,6 +31,8 @@ def create_gemini_content(
     page_metadata: PageMetadata,
     png_data: bytes,
 ) -> list[types.Part]:
+    from google.genai import types  # noqa: PLC0415
+
     prompt = PROMPT_LOADER.get_prompt(
         PromptId.OCR_TRANSCRIPTION, custom_type=page_metadata.file_name_basis
     )

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -4,10 +4,42 @@ These tests verify that the server correctly handles X-Forwarded-* headers
 when deployed behind a reverse proxy, with different proxy modes.
 """
 
+import subprocess
+import sys
+
 import pytest
 from aiohttp.test_utils import TestClient
 
 from supernote.models.file_device import FileUploadApplyLocalDTO
+
+
+def test_import_does_not_load_heavy_optional_dependencies() -> None:
+    """Importing the server bootstrap module should not eagerly import the
+    heavy `mcp` / `google-genai` dependencies (see issue #106).
+
+    `mcp` is only needed once the server actually starts up, and
+    `google-genai` is only needed once a Gemini API key is configured. Run
+    in a subprocess so the check isn't polluted by other tests in this
+    session having already imported these modules.
+    """
+    check = (
+        "import sys; import supernote.server.app; "
+        "loaded = sorted("
+        "m for m in sys.modules "
+        "if m == 'mcp' or m.startswith('mcp.') "
+        "or m == 'google.genai' or m.startswith('google.genai.')"
+        "); "
+        "print(','.join(loaded))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", check],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "", (
+        f"Heavy dependency modules unexpectedly loaded: {result.stdout.strip()}"
+    )
 
 
 # Test for default proxy mode (disabled)

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -13,21 +13,19 @@ from aiohttp.test_utils import TestClient
 from supernote.models.file_device import FileUploadApplyLocalDTO
 
 
-def test_import_does_not_load_heavy_optional_dependencies() -> None:
-    """Importing the server bootstrap module should not eagerly import the
-    heavy `mcp` / `google-genai` dependencies (see issue #106).
+def test_import_does_not_load_google_genai() -> None:
+    """Importing the server bootstrap module should not eagerly import
+    `google-genai` (see issue #106).
 
-    `mcp` is only needed once the server actually starts up, and
     `google-genai` is only needed once a Gemini API key is configured. Run
     in a subprocess so the check isn't polluted by other tests in this
-    session having already imported these modules.
+    session having already imported the module.
     """
     check = (
         "import sys; import supernote.server.app; "
         "loaded = sorted("
         "m for m in sys.modules "
-        "if m == 'mcp' or m.startswith('mcp.') "
-        "or m == 'google.genai' or m.startswith('google.genai.')"
+        "if m == 'google.genai' or m.startswith('google.genai.')"
         "); "
         "print(','.join(loaded))"
     )
@@ -38,7 +36,7 @@ def test_import_does_not_load_heavy_optional_dependencies() -> None:
         check=True,
     )
     assert result.stdout.strip() == "", (
-        f"Heavy dependency modules unexpectedly loaded: {result.stdout.strip()}"
+        f"google-genai modules unexpectedly loaded: {result.stdout.strip()}"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #106, narrowed after review.

`google-genai` was imported at module scope, so any process that imports
`supernote.server` (or `supernote.server.app`) paid its full transitive
import cost even when no Gemini API key is configured and `GeminiService`
never constructs a client.

**This PR no longer touches `mcp`.** The original version also deferred
`supernote.server.mcp.*` from module scope into `on_startup_handler`, but
@allenporter pointed out that buys nothing for a running server:
`on_startup_handler` runs unconditionally on startup, and there is no flag
today that skips mounting MCP — so the import happens either way, just at a
different point. That commit (`a78d91b1`) reverted the `mcp` half; only the
`google-genai` deferral, which *is* conditional on `api_key`, remains.

## What was eager and why it mattered

- `supernote/server/services/gemini.py` imported `google.genai` /
  `google.genai.types` at the top, even though `GeminiService.__init__`
  already gates client creation behind `if self.api_key:`.
- `supernote/server/services/processor_modules/gemini_ocr.py` and
  `supernote/server/utils/gemini_content.py` imported
  `google.genai.types` at module scope for both type annotations and
  runtime calls, even though those code paths only ever execute after
  `gemini_service.is_configured` is checked.

## What moved

- `gemini.py`: `from google import genai` moved inside the existing
  `if self.api_key:` branch. Type annotations preserved via
  `from __future__ import annotations` + `if TYPE_CHECKING:`.
- `gemini_ocr.py`: `from google.genai import types` moved into
  `GeminiOcrModule.process`, right before it's used.
- `gemini_content.py`: `from google.genai import types` moved inside
  `create_gemini_content`, with the return-type annotation preserved
  the same way.

No behavior changes: when a Gemini key is configured, everything still
works identically. If the optional dependency is missing, the
`ImportError` surfaces at the same logical point or later/closer to
actual use, not somewhere unrelated.

## Numbers (before/after), re-measured against the current diff

Measured on this branch (`a78d91b`) vs `main` (`d5b3e84`), via
`sys.modules` diffing after `import supernote.server` and
`python -X importtime`. Both extras (`server`, `client`) installed so
`aiohttp_remotes` resolves and the import completes end to end.

| Metric (`import supernote.server`) | Before (`main`) | After (this PR) | Change |
| --- | --- | --- | --- |
| Modules loaded | 1707 | 1442 | **-265 modules (-15.5%)** |
| `mcp` submodules loaded | 107 | 107 | **0 (unchanged, as expected)** |
| `google.genai` submodules loaded | 158 | 0 | -158 |
| Cumulative import time (`supernote.server`) | 1,022,437 µs | 835,938 µs | **-18.2%** |

The `mcp` row not moving is exactly @allenporter's point confirmed by
measurement, not just conceded in the thread: whether `mcp` is deferred to
`on_startup_handler` or not, all 107 of its submodules load either way once
the server actually starts, since nothing gates that today. That's why this
PR no longer touches it.

(The original submission's table included a run where `mcp` *was* deferred,
which changes what "after" measures — those figures aren't reused here.)

## Validation

- `uv run ruff check` / `uv run ruff format --check` — pass on all
  changed files (local imports use `# noqa: PLC0415`, matching the
  existing convention in `supernote/cli/client.py`).
- `uv run ty check` — pass on all changed files.
- `uv run pytest -n auto -m "not integration"` — 569 passed (same as
  base branch).
- `test_import_does_not_load_google_genai` in `tests/server/test_app.py`:
  runs a subprocess that imports `supernote.server.app` and asserts no
  `google.genai` module lands in `sys.modules`, directly regression-testing
  the remaining half of this issue.
- Manually verified `GeminiService("fake-key").is_configured` still
  constructs a real `google.genai.client.Client` and imports
  `google.genai` when a key *is* configured.
- `git status` clean, `uv.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
