### PR TITLE
fix(summary): auto-calculate md5 and timestamp fallbacks

### DIFF
--- a/supernote/alembic/README.md
+++ b/supernote/alembic/README.md
@@ -1,0 +1,40 @@
+# Supernote Database Migrations & Revision History
+
+This directory contains database schema and data migration scripts managed by [Alembic](https://alembic.sqlalchemy.org/).
+
+## Revision History
+
+| Revision ID | Date | Description |
+| :--- | :--- | :--- |
+| `0543a383957b` | 2026-08-01 | Initial database schema (`f_user_file`, `f_summary`, `f_user`, `t_schedule_task`, etc.) |
+| `7a8291f043bc` | 2026-08-02 | Added links, sorting, and planner sort fields to `t_schedule_task` |
+| `b8e9c0d1e2f3` | 2026-08-09 | Backfill missing `md5_hash`, `creation_time`, and `last_modified_time` in `f_summary` |
+
+## Migration Guidelines & Conventions
+
+1. **Location**: All revision scripts are stored in `supernote/alembic/versions/`.
+2. **File Naming**: `<revision_id>_<snake_case_description>.py`.
+3. **Data Backfills**: Non-destructive data backfills (such as calculating hashes or setting missing timestamps) should be executed inside `upgrade()` using `op.get_bind()` and SQLAlchemy `sa.text()` statements.
+4. **Automatic Execution**: Database migrations run automatically during server startup in `supernote/server/app.py` via `run_migrations(config.db_url)`.
+
+## Useful CLI Commands
+
+### View Migration History
+```bash
+alembic -c supernote/alembic.ini history
+```
+
+### View Current Database Version
+```bash
+alembic -c supernote/alembic.ini current
+```
+
+### Create a New Migration Revision
+```bash
+alembic -c supernote/alembic.ini revision -m "description_of_changes"
+```
+
+### Manually Apply Migrations
+```bash
+alembic -c supernote/alembic.ini upgrade head
+```

--- a/supernote/alembic/versions/b8e9c0d1e2f3_backfill_summary_md5_and_timestamps.py
+++ b/supernote/alembic/versions/b8e9c0d1e2f3_backfill_summary_md5_and_timestamps.py
@@ -1,0 +1,58 @@
+"""backfill summary md5 and timestamps
+
+Revision ID: b8e9c0d1e2f3
+Revises: 7a8291f043bc
+Create Date: 2026-08-09 15:30:00.000000
+
+"""
+
+import hashlib
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b8e9c0d1e2f3"
+down_revision: Union[str, None] = "7a8291f043bc"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. Backfill creation_time with create_time if NULL
+    bind.execute(
+        sa.text(
+            "UPDATE f_summary SET creation_time = create_time WHERE creation_time IS NULL AND create_time IS NOT NULL"
+        )
+    )
+
+    # 2. Backfill last_modified_time with update_time or create_time if NULL
+    bind.execute(
+        sa.text(
+            "UPDATE f_summary SET last_modified_time = COALESCE(update_time, create_time) WHERE last_modified_time IS NULL"
+        )
+    )
+
+    # 3. Backfill md5_hash from content if NULL
+    result = bind.execute(
+        sa.text(
+            "SELECT id, content FROM f_summary WHERE md5_hash IS NULL AND content IS NOT NULL"
+        )
+    )
+    rows = result.fetchall()
+    for row in rows:
+        summary_id, content = row[0], row[1]
+        if content:
+            md5_hex = hashlib.md5(content.encode("utf-8")).hexdigest()
+            bind.execute(
+                sa.text("UPDATE f_summary SET md5_hash = :md5 WHERE id = :id"),
+                {"md5": md5_hex, "id": summary_id},
+            )
+
+
+def downgrade() -> None:
+    # Data backfill migrations are non-destructive and do not require schema rollback
+    pass

--- a/supernote/server/README.md
+++ b/supernote/server/README.md
@@ -76,7 +76,7 @@ docker run -d \
 
 Supernote Knowledge Hub is built for long-term stability:
 
-- **Database Migrations**: Uses Alembic for seamless schema updates.
+- **Database Migrations**: Uses Alembic for seamless schema and data updates (see [Alembic Migration History & Conventions](../alembic/README.md)).
 - **Background Polling**: Automatically recovers stalled processing tasks.
 - **Integrity Checks**: Periodically verifies file storage consistency.
 - **Storage Quotas**: Manage user storage limits effectively.

--- a/supernote/server/db/migrations.py
+++ b/supernote/server/db/migrations.py
@@ -8,14 +8,14 @@ import alembic.config
 logger = logging.getLogger(__name__)
 
 
-def run_migrations(db_url: str) -> None:
-    """
-    Run pending database migrations using Alembic.
+def run_migrations(db_url: str, target_revision: str = "head") -> None:
+    """Run pending database migrations using Alembic.
 
     Args:
         db_url: The database connection URL to use for migrations.
                This overrides the url in alembic.ini to ensure we target
                the correct environment (prod, test, etc).
+        target_revision: Revision to migrate to (default: "head").
     """
     # Locate alembic.ini inside the supernote package
     traversable = importlib.resources.files("supernote") / "alembic.ini"
@@ -39,6 +39,6 @@ def run_migrations(db_url: str) -> None:
             db_path = Path(path_str)
             db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    logger.info("Running database migrations...")
-    alembic.command.upgrade(alembic_cfg, "head")
+    logger.info("Running database migrations to %s...", target_revision)
+    alembic.command.upgrade(alembic_cfg, target_revision)
     logger.info("Database migrations complete.")

--- a/supernote/server/services/summary.py
+++ b/supernote/server/services/summary.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+import time
 import uuid
 
 from sqlalchemy import and_, select
@@ -37,18 +39,31 @@ def _to_tag_item(do: SummaryTagDO) -> SummaryTagItem:
 
 def _to_summary_info_item(do: SummaryDO) -> SummaryInfoItem:
     """Convert SummaryDO to SummaryInfoItem."""
+    now_ms = int(time.time() * 1000)
+    md5 = do.md5_hash
+    if not md5 and do.content:
+        md5 = hashlib.md5(do.content.encode("utf-8")).hexdigest()
+
     return SummaryInfoItem(
         id=do.id,
         user_id=do.user_id,
-        md5_hash=do.md5_hash,
+        md5_hash=md5,
         handwrite_md5=do.handwrite_md5,
         comment_handwrite_name=do.comment_handwrite_name,
-        last_modified_time=do.last_modified_time,
+        last_modified_time=do.last_modified_time
+        or do.update_time
+        or do.create_time
+        or now_ms,
     )
 
 
 def _to_summary_item(do: SummaryDO) -> SummaryItem:
     """Convert SummaryDO to SummaryItem."""
+    now_ms = int(time.time() * 1000)
+    md5 = do.md5_hash
+    if not md5 and do.content:
+        md5 = hashlib.md5(do.content.encode("utf-8")).hexdigest()
+
     return SummaryItem(
         id=do.id,
         file_id=do.file_id,
@@ -63,14 +78,17 @@ def _to_summary_item(do: SummaryDO) -> SummaryItem:
         is_summary_group=BooleanEnum.of(bool(do.is_summary_group)),
         description=do.description,
         tags=do.tags,
-        md5_hash=do.md5_hash,
+        md5_hash=md5,
         metadata=do.extra_metadata,
         comment_str=do.comment_str,
         comment_handwrite_name=do.comment_handwrite_name,
         handwrite_inner_name=do.handwrite_inner_name,
         handwrite_md5=do.handwrite_md5,
-        creation_time=do.creation_time,
-        last_modified_time=do.last_modified_time,
+        creation_time=do.creation_time or do.create_time or now_ms,
+        last_modified_time=do.last_modified_time
+        or do.update_time
+        or do.create_time
+        or now_ms,
         is_deleted=BooleanEnum.of(bool(do.is_deleted)),
         create_time=do.create_time,
         update_time=do.update_time,
@@ -138,6 +156,10 @@ class SummaryService:
     async def add_summary(self, user_email: str, dto: AddSummaryDTO) -> SummaryItem:
         """Add a new summary."""
         user_id = await self.user_service.get_user_id(user_email)
+        md5 = dto.md5_hash
+        if not md5 and dto.content:
+            md5 = hashlib.md5(dto.content.encode("utf-8")).hexdigest()
+
         async with self.session_manager.session() as session:
             summary_do = SummaryDO(
                 user_id=user_id,
@@ -150,7 +172,7 @@ class SummaryService:
                 source_type=dto.source_type,
                 is_summary_group=False,
                 tags=dto.tags,
-                md5_hash=dto.md5_hash,
+                md5_hash=md5,
                 extra_metadata=dto.metadata,
                 comment_str=dto.comment_str,
                 comment_handwrite_name=dto.comment_handwrite_name,
@@ -175,6 +197,10 @@ class SummaryService:
 
             if dto.content is not None:
                 summary_do.content = dto.content
+                if dto.md5_hash is None:
+                    summary_do.md5_hash = hashlib.md5(
+                        dto.content.encode("utf-8")
+                    ).hexdigest()
             if dto.tags is not None:
                 summary_do.tags = dto.tags
             if dto.metadata is not None:
@@ -237,7 +263,7 @@ class SummaryService:
         async with self.session_manager.session() as session:
             summary_do = SummaryDO(
                 user_id=user_id,
-                unique_identifier=dto.unique_identifier,
+                unique_identifier=dto.unique_identifier or str(uuid.uuid4()),
                 name=dto.name,
                 md5_hash=dto.md5_hash,
                 description=dto.description,
@@ -417,3 +443,29 @@ class SummaryService:
             result = await session.execute(stmt)
             summaries = list(result.scalars().all())
             return [_to_summary_item(s) for s in summaries]
+
+    async def backfill_missing_fields(self) -> int:
+        """Backfill missing md5_hash, creation_time, and last_modified_time for existing summary records."""
+        now_ms = int(time.time() * 1000)
+        async with self.session_manager.session() as session:
+            stmt = select(SummaryDO).where(
+                (SummaryDO.md5_hash.is_(None) & SummaryDO.content.isnot(None))
+                | SummaryDO.creation_time.is_(None)
+                | SummaryDO.last_modified_time.is_(None)
+            )
+            result = await session.execute(stmt)
+            summaries = list(result.scalars().all())
+            count = 0
+            for s in summaries:
+                if not s.creation_time:
+                    s.creation_time = s.create_time or now_ms
+                if not s.last_modified_time:
+                    s.last_modified_time = s.update_time or s.create_time or now_ms
+                if not s.md5_hash and s.content:
+                    s.md5_hash = hashlib.md5(s.content.encode("utf-8")).hexdigest()
+                count += 1
+
+            if count > 0:
+                await session.commit()
+                logger.info("Backfilled missing summary fields for %d records", count)
+            return count

--- a/supernote/server/services/summary.py
+++ b/supernote/server/services/summary.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import time
 import uuid
 
 from sqlalchemy import and_, select
@@ -143,6 +144,10 @@ class SummaryService:
         if not md5 and dto.content:
             md5 = hashlib.md5(dto.content.encode("utf-8")).hexdigest()
 
+        now_ms = int(time.time() * 1000)
+        creation_time = dto.creation_time or now_ms
+        last_modified_time = dto.last_modified_time or now_ms
+
         async with self.session_manager.session() as session:
             summary_do = SummaryDO(
                 user_id=user_id,
@@ -161,8 +166,8 @@ class SummaryService:
                 comment_handwrite_name=dto.comment_handwrite_name,
                 handwrite_inner_name=dto.handwrite_inner_name,
                 handwrite_md5=dto.handwrite_md5,
-                creation_time=dto.creation_time,
-                last_modified_time=dto.last_modified_time,
+                creation_time=creation_time,
+                last_modified_time=last_modified_time,
                 author=dto.author,
             )
             session.add(summary_do)

--- a/supernote/server/services/summary.py
+++ b/supernote/server/services/summary.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import time
 import uuid
 
 from sqlalchemy import and_, select

--- a/supernote/server/services/summary.py
+++ b/supernote/server/services/summary.py
@@ -39,31 +39,18 @@ def _to_tag_item(do: SummaryTagDO) -> SummaryTagItem:
 
 def _to_summary_info_item(do: SummaryDO) -> SummaryInfoItem:
     """Convert SummaryDO to SummaryInfoItem."""
-    now_ms = int(time.time() * 1000)
-    md5 = do.md5_hash
-    if not md5 and do.content:
-        md5 = hashlib.md5(do.content.encode("utf-8")).hexdigest()
-
     return SummaryInfoItem(
         id=do.id,
         user_id=do.user_id,
-        md5_hash=md5,
+        md5_hash=do.md5_hash,
         handwrite_md5=do.handwrite_md5,
         comment_handwrite_name=do.comment_handwrite_name,
-        last_modified_time=do.last_modified_time
-        or do.update_time
-        or do.create_time
-        or now_ms,
+        last_modified_time=do.last_modified_time or do.update_time or do.create_time,
     )
 
 
 def _to_summary_item(do: SummaryDO) -> SummaryItem:
     """Convert SummaryDO to SummaryItem."""
-    now_ms = int(time.time() * 1000)
-    md5 = do.md5_hash
-    if not md5 and do.content:
-        md5 = hashlib.md5(do.content.encode("utf-8")).hexdigest()
-
     return SummaryItem(
         id=do.id,
         file_id=do.file_id,
@@ -78,17 +65,14 @@ def _to_summary_item(do: SummaryDO) -> SummaryItem:
         is_summary_group=BooleanEnum.of(bool(do.is_summary_group)),
         description=do.description,
         tags=do.tags,
-        md5_hash=md5,
+        md5_hash=do.md5_hash,
         metadata=do.extra_metadata,
         comment_str=do.comment_str,
         comment_handwrite_name=do.comment_handwrite_name,
         handwrite_inner_name=do.handwrite_inner_name,
         handwrite_md5=do.handwrite_md5,
-        creation_time=do.creation_time or do.create_time or now_ms,
-        last_modified_time=do.last_modified_time
-        or do.update_time
-        or do.create_time
-        or now_ms,
+        creation_time=do.creation_time or do.create_time,
+        last_modified_time=do.last_modified_time or do.update_time or do.create_time,
         is_deleted=BooleanEnum.of(bool(do.is_deleted)),
         create_time=do.create_time,
         update_time=do.update_time,

--- a/supernote/server/services/summary.py
+++ b/supernote/server/services/summary.py
@@ -443,29 +443,3 @@ class SummaryService:
             result = await session.execute(stmt)
             summaries = list(result.scalars().all())
             return [_to_summary_item(s) for s in summaries]
-
-    async def backfill_missing_fields(self) -> int:
-        """Backfill missing md5_hash, creation_time, and last_modified_time for existing summary records."""
-        now_ms = int(time.time() * 1000)
-        async with self.session_manager.session() as session:
-            stmt = select(SummaryDO).where(
-                (SummaryDO.md5_hash.is_(None) & SummaryDO.content.isnot(None))
-                | SummaryDO.creation_time.is_(None)
-                | SummaryDO.last_modified_time.is_(None)
-            )
-            result = await session.execute(stmt)
-            summaries = list(result.scalars().all())
-            count = 0
-            for s in summaries:
-                if not s.creation_time:
-                    s.creation_time = s.create_time or now_ms
-                if not s.last_modified_time:
-                    s.last_modified_time = s.update_time or s.create_time or now_ms
-                if not s.md5_hash and s.content:
-                    s.md5_hash = hashlib.md5(s.content.encode("utf-8")).hexdigest()
-                count += 1
-
-            if count > 0:
-                await session.commit()
-                logger.info("Backfilled missing summary fields for %d records", count)
-            return count

--- a/supernote/server/utils/paths.py
+++ b/supernote/server/utils/paths.py
@@ -12,6 +12,19 @@ def get_file_chunk_path(object_name: str, part_number: int) -> str:
     return f"{object_name}.part.{part_number}"
 
 
+def extract_clean_uuid(file_basis: str) -> str:
+    """Extract clean UUID portion from a storage key or path."""
+    raw = (
+        file_basis.replace("-transcript", "")
+        .replace("-summary", "")
+        .rsplit("/", 1)[-1]
+        .split(".")[0]
+    )
+    if len(raw) >= 36 and raw[36:37] == "-":
+        return raw[:36]
+    return raw
+
+
 def get_summary_id(file_basis: str) -> str:
     """Generate a unique identifier for an AI summary."""
     return f"{file_basis}-summary"

--- a/supernote/server/utils/paths.py
+++ b/supernote/server/utils/paths.py
@@ -12,19 +12,6 @@ def get_file_chunk_path(object_name: str, part_number: int) -> str:
     return f"{object_name}.part.{part_number}"
 
 
-def extract_clean_uuid(file_basis: str) -> str:
-    """Extract clean UUID portion from a storage key or path."""
-    raw = (
-        file_basis.replace("-transcript", "")
-        .replace("-summary", "")
-        .rsplit("/", 1)[-1]
-        .split(".")[0]
-    )
-    if len(raw) >= 36 and raw[36:37] == "-":
-        return raw[:36]
-    return raw
-
-
 def get_summary_id(file_basis: str) -> str:
     """Generate a unique identifier for an AI summary."""
     return f"{file_basis}-summary"

--- a/tests/server/db/test_migrations.py
+++ b/tests/server/db/test_migrations.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import shutil
 from pathlib import Path
 
@@ -74,12 +75,31 @@ def test_migration_upgrades_successfully(migrated_db: str) -> None:
         # Check if the 'alembic_version' table exists and has the head revision
         result = conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
-        assert version is not None
+        assert version == "b8e9c0d1e2f3"
 
         # Check if a known table exists (e.g. users)
         result = conn.execute(text("SELECT count(*) FROM users"))
         count = result.scalar()
         assert count is not None
         assert count >= 0
+
+    engine.dispose()
+
+
+def test_summary_backfill_migration(migrated_db: str) -> None:
+    """Verify that summary md5_hash, creation_time, and last_modified_time are backfilled by Alembic."""
+    engine = create_engine(migrated_db)
+    with engine.connect() as conn:
+        # Verify items from db_v1_populated.sqlite were backfilled by Alembic upgrade head
+        result = conn.execute(
+            text(
+                "SELECT id, content, creation_time, last_modified_time, md5_hash FROM f_summary"
+            )
+        )
+        rows = result.fetchall()
+        for row in rows:
+            content, creation_time, last_modified_time, md5_hash = row[1], row[2], row[3], row[4]
+            if content and md5_hash:
+                assert md5_hash == hashlib.md5(content.encode("utf-8")).hexdigest()
 
     engine.dispose()

--- a/tests/server/db/test_migrations.py
+++ b/tests/server/db/test_migrations.py
@@ -98,14 +98,23 @@ def test_summary_backfill_migration(migrated_db: str) -> None:
         )
         rows = result.fetchall()
         for row in rows:
-            content, creation_time, last_modified_time, md5_hash = row[1], row[2], row[3], row[4]
+            content, creation_time, last_modified_time, md5_hash = (
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+            )
+            assert creation_time is not None
+            assert last_modified_time is not None
             if content and md5_hash:
                 assert md5_hash == hashlib.md5(content.encode("utf-8")).hexdigest()
 
     engine.dispose()
 
 
-def test_summary_api_fixture_migration_backfill(tmp_path: Path, alembic_config: Config) -> None:
+def test_summary_api_fixture_migration_backfill(
+    tmp_path: Path, alembic_config: Config
+) -> None:
     """Verify that Alembic upgrade head backfills the API-generated legacy fixture."""
     fixture_path = Path("tests/fixtures/db_v1_summary_api.sqlite").absolute()
     db_path = tmp_path / "summary_api_migrated.db"
@@ -118,12 +127,19 @@ def test_summary_api_fixture_migration_backfill(tmp_path: Path, alembic_config: 
     engine = create_engine(migration_db_url)
     with engine.connect() as conn:
         result = conn.execute(
-            text("SELECT id, content, creation_time, last_modified_time, md5_hash FROM f_summary")
+            text(
+                "SELECT id, content, creation_time, last_modified_time, md5_hash FROM f_summary"
+            )
         )
         rows = result.fetchall()
         assert len(rows) >= 1
         for row in rows:
-            content, creation_time, last_modified_time, md5_hash = row[1], row[2], row[3], row[4]
+            content, creation_time, last_modified_time, md5_hash = (
+                row[1],
+                row[2],
+                row[3],
+                row[4],
+            )
             assert creation_time is not None
             assert last_modified_time is not None
             assert md5_hash == hashlib.md5(content.encode("utf-8")).hexdigest()

--- a/tests/server/db/test_migrations.py
+++ b/tests/server/db/test_migrations.py
@@ -103,3 +103,29 @@ def test_summary_backfill_migration(migrated_db: str) -> None:
                 assert md5_hash == hashlib.md5(content.encode("utf-8")).hexdigest()
 
     engine.dispose()
+
+
+def test_summary_api_fixture_migration_backfill(tmp_path: Path, alembic_config: Config) -> None:
+    """Verify that Alembic upgrade head backfills the API-generated legacy fixture."""
+    fixture_path = Path("tests/fixtures/db_v1_summary_api.sqlite").absolute()
+    db_path = tmp_path / "summary_api_migrated.db"
+    shutil.copy(fixture_path, db_path)
+
+    migration_db_url = f"sqlite:///{db_path}"
+    alembic_config.set_main_option("sqlalchemy.url", migration_db_url)
+    command.upgrade(alembic_config, "head")
+
+    engine = create_engine(migration_db_url)
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("SELECT id, content, creation_time, last_modified_time, md5_hash FROM f_summary")
+        )
+        rows = result.fetchall()
+        assert len(rows) >= 1
+        for row in rows:
+            content, creation_time, last_modified_time, md5_hash = row[1], row[2], row[3], row[4]
+            assert creation_time is not None
+            assert last_modified_time is not None
+            assert md5_hash == hashlib.md5(content.encode("utf-8")).hexdigest()
+
+    engine.dispose()

--- a/tests/server/integration/db/test_db_v1_summary_api.py
+++ b/tests/server/integration/db/test_db_v1_summary_api.py
@@ -1,6 +1,7 @@
-"""Integration test verifying unmigrated summary API behavior on db_v1_summary_api fixture."""
+"""Integration tests for summary server API across unmigrated, migrated, and post-migration creation flows."""
 
 import hashlib
+import shutil
 from pathlib import Path
 
 import jwt
@@ -17,26 +18,24 @@ from supernote.server.db.migrations import run_migrations
 from supernote.server.services.user import JWT_ALGORITHM, UserService
 
 
-async def test_unmigrated_summary_api_creation(tmp_path: Path) -> None:
-    """Verify legacy summary creation and query behavior over server API."""
+async def test_unmigrated_summary_api_query(tmp_path: Path) -> None:
+    """(a) Pre-PR test: Verify unmigrated legacy db fixture returns NULL for md5_hash and timestamps on revision 7a8291f043bc."""
+    fixture_path = Path("tests/fixtures/db_v1_summary_api.sqlite").absolute()
     storage_dir = tmp_path / "storage"
     db_file = storage_dir / "system" / "supernote.db"
     db_file.parent.mkdir(parents=True, exist_ok=True)
-    sync_db_url = f"sqlite:///{db_file}"
+    shutil.copy(fixture_path, db_file)
 
-    run_migrations(sync_db_url)
+    sync_db_url = f"sqlite:///{db_file}"
+    # Target unmigrated revision prior to b8e9c0d1e2f3
+    run_migrations(sync_db_url, "7a8291f043bc")
 
     config = ServerConfig(
         storage_dir=str(storage_dir),
         auth=AuthConfig(secret_key="test-secret-key-32-characters-long!!"),
+        mcp_port=0,
     )
     app = create_app(config)
-
-    user_service: UserService = app["user_service"]
-    pwd_md5 = hashlib.md5(b"password123").hexdigest()
-    await user_service.register(
-        UserRegisterDTO(email="api_test@example.com", password=pwd_md5)
-    )
 
     secret = config.auth.secret_key
     token = jwt.encode({"sub": "api_test@example.com"}, secret, algorithm=JWT_ALGORITHM)
@@ -57,9 +56,141 @@ async def test_unmigrated_summary_api_creation(tmp_path: Path) -> None:
     auth_client = Client(test_client.session, auth=TokenAuth(), host=base_url)
     summary_client = SummaryClient(auth_client)
 
+    legacy_summary_id = 741735919668691745
+    query_resp = await summary_client.query_summaries(ids=[legacy_summary_id])
+    assert query_resp.success
+    assert len(query_resp.summary_do_list) == 1
+
+    summary = query_resp.summary_do_list[0]
+    assert summary.id == legacy_summary_id
+    assert summary.md5_hash is None
+
+    hash_dto = QuerySummaryDTO(ids=[legacy_summary_id])
+    info_resp = await summary_client.query_summary_hash(hash_dto)
+    assert info_resp.success
+    matching_infos = [
+        item for item in info_resp.summary_info_vo_list if item.id == legacy_summary_id
+    ]
+    assert len(matching_infos) == 1
+    info_item = matching_infos[0]
+    assert info_item.md5_hash is None
+
+    await test_client.close()
+
+
+async def test_migrated_legacy_db_summary_api_query(tmp_path: Path) -> None:
+    """(b) Migration test: Swap in unmigrated fixture db_v1_summary_api, run Alembic upgrade, verify non-null backfilled fields over HTTP API."""
+    fixture_path = Path("tests/fixtures/db_v1_summary_api.sqlite").absolute()
+    storage_dir = tmp_path / "storage"
+    db_file = storage_dir / "system" / "supernote.db"
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(fixture_path, db_file)
+
+    sync_db_url = f"sqlite:///{db_file}"
+    run_migrations(sync_db_url)
+
+    config = ServerConfig(
+        storage_dir=str(storage_dir),
+        auth=AuthConfig(secret_key="test-secret-key-32-characters-long!!"),
+        mcp_port=0,
+    )
+    app = create_app(config)
+
+    secret = config.auth.secret_key
+    token = jwt.encode({"sub": "api_test@example.com"}, secret, algorithm=JWT_ALGORITHM)
+    coordination_service = app["coordination_service"]
+    await coordination_service.set_value(
+        f"session:{token}", "api_test@example.com|", ttl=3600
+    )
+
+    class TokenAuth(AbstractAuth):
+        async def async_get_access_token(self) -> str:
+            return token
+
+    test_server = TestServer(app)
+    test_client = TestClient(test_server)
+    await test_client.start_server()
+    base_url = str(test_client.make_url("/"))
+
+    auth_client = Client(test_client.session, auth=TokenAuth(), host=base_url)
+    summary_client = SummaryClient(auth_client)
+
+    legacy_summary_id = 741735919668691745
+    query_resp = await summary_client.query_summaries(ids=[legacy_summary_id])
+    assert query_resp.success
+    assert len(query_resp.summary_do_list) == 1
+
+    summary = query_resp.summary_do_list[0]
+    expected_md5 = hashlib.md5(b"End-to-end API generated summary content.").hexdigest()
+    assert summary.id == legacy_summary_id
+    assert summary.md5_hash == expected_md5
+    assert summary.creation_time is not None
+    assert summary.last_modified_time is not None
+
+    hash_dto = QuerySummaryDTO(ids=[legacy_summary_id])
+    info_resp = await summary_client.query_summary_hash(hash_dto)
+    assert info_resp.success
+    matching_infos = [
+        item for item in info_resp.summary_info_vo_list if item.id == legacy_summary_id
+    ]
+    assert len(matching_infos) == 1
+    info_item = matching_infos[0]
+    assert info_item.md5_hash == expected_md5
+    assert info_item.last_modified_time is not None
+
+    await test_client.close()
+
+
+async def test_post_migration_new_summary_creation(tmp_path: Path) -> None:
+    """(c) Post-migration test: Verify new summary creation post-migration sets non-null md5_hash and timestamps over HTTP API."""
+    storage_dir = tmp_path / "storage"
+    db_file = storage_dir / "system" / "supernote.db"
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    sync_db_url = f"sqlite:///{db_file}"
+
+    # Run migrations to head
+    run_migrations(sync_db_url)
+
+    config = ServerConfig(
+        storage_dir=str(storage_dir),
+        auth=AuthConfig(secret_key="test-secret-key-32-characters-long!!"),
+        mcp_port=0,
+    )
+    app = create_app(config)
+
+    user_service: UserService = app["user_service"]
+    pwd_md5 = hashlib.md5(b"password123").hexdigest()
+    await user_service.register(
+        UserRegisterDTO(email="new_api_test@example.com", password=pwd_md5)
+    )
+
+    secret = config.auth.secret_key
+    token = jwt.encode(
+        {"sub": "new_api_test@example.com"}, secret, algorithm=JWT_ALGORITHM
+    )
+    coordination_service = app["coordination_service"]
+    await coordination_service.set_value(
+        f"session:{token}", "new_api_test@example.com|", ttl=3600
+    )
+
+    class TokenAuth(AbstractAuth):
+        async def async_get_access_token(self) -> str:
+            return token
+
+    test_server = TestServer(app)
+    test_client = TestClient(test_server)
+    await test_client.start_server()
+    base_url = str(test_client.make_url("/"))
+
+    auth_client = Client(test_client.session, auth=TokenAuth(), host=base_url)
+    summary_client = SummaryClient(auth_client)
+
+    content = "Post-migration newly created summary content."
+    expected_md5 = hashlib.md5(content.encode("utf-8")).hexdigest()
+
     add_dto = AddSummaryDTO(
-        content="End-to-end API generated summary content.",
-        source_path="/Document/E2E.note",
+        content=content,
+        source_path="/Document/NewPostMigration.note",
         author="API Test",
     )
     add_resp = await summary_client.add_summary(add_dto)
@@ -72,7 +203,9 @@ async def test_unmigrated_summary_api_creation(tmp_path: Path) -> None:
     assert len(query_resp.summary_do_list) == 1
     summary = query_resp.summary_do_list[0]
     assert summary.id == summary_id
-    assert summary.content == "End-to-end API generated summary content."
+    assert summary.md5_hash == expected_md5
+    assert summary.creation_time is not None
+    assert summary.last_modified_time is not None
 
     hash_dto = QuerySummaryDTO(ids=[summary_id])
     info_resp = await summary_client.query_summary_hash(hash_dto)
@@ -81,5 +214,8 @@ async def test_unmigrated_summary_api_creation(tmp_path: Path) -> None:
         item for item in info_resp.summary_info_vo_list if item.id == summary_id
     ]
     assert len(matching_infos) == 1
+    info_item = matching_infos[0]
+    assert info_item.md5_hash == expected_md5
+    assert info_item.last_modified_time is not None
 
     await test_client.close()

--- a/tests/server/routes/test_summary.py
+++ b/tests/server/routes/test_summary.py
@@ -72,6 +72,9 @@ async def test_summary_crud(summary_client: SummaryClient) -> None:
     assert summary.data_source == "TEST"
     assert summary.tags == "test,summary"
     assert summary.metadata == '{"key": "value"}'
+    assert summary.creation_time is not None
+    assert summary.last_modified_time is not None
+    assert summary.md5_hash is not None
 
     # 3. Update the summary
     update_dto = UpdateSummaryDTO(


### PR DESCRIPTION
Automatically calculates missing MD5 hashes for summaries on creation/update, and resolves creationTime and lastModifiedTime fallbacks dynamically from database audit timestamps.