### PR TITLE
fix(client): guard optional python-socketio dependency import

### DIFF
--- a/supernote/client/__init__.py
+++ b/supernote/client/__init__.py
@@ -13,6 +13,8 @@ Example:
     sn = Supernote.from_token("your-token", host="http://localhost:8080")
 """
 
+from typing import Any
+
 from . import (
     admin,
     auth,
@@ -21,12 +23,18 @@ from . import (
     extended,
     login_client,
     schedule,
-    socket,
     summary,
     web,
 )
-from .api import Supernote
-from .client import Client
+
+socket: Any = None
+try:
+    from . import socket
+except ImportError:
+    pass
+
+from .api import Supernote  # noqa: E402
+from .client import Client  # noqa: E402
 
 __all__ = [
     "Client",

--- a/supernote/client/socket.py
+++ b/supernote/client/socket.py
@@ -6,10 +6,14 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
-import socketio
+socketio: Any = None
+try:
+    import socketio
+except ImportError:
+    pass
 
-from supernote.client.exceptions import SupernoteSocketError
-from supernote.models.socket import (
+from supernote.client.exceptions import SupernoteSocketError  # noqa: E402
+from supernote.models.socket import (  # noqa: E402
     SocketHandshakeParams,
     SocketIoClientMessage,
     SocketIoEvent,
@@ -26,6 +30,11 @@ class SupernoteSocketClient:
     """Async Socket.IO client for interacting with the Supernote real-time server."""
 
     def __init__(self, host: str) -> None:
+        if socketio is None:
+            raise SupernoteSocketError(
+                "python-socketio is required for SupernoteSocketClient. "
+                "Install supernote with client extras: pip install supernote[client]"
+            )
         self.host = host.rstrip("/")
         self._sio = socketio.AsyncClient()
         self._message_queue: asyncio.Queue[SocketMessageData] = asyncio.Queue()

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -1,5 +1,8 @@
 """Tests for the Supernote session API."""
 
+import sys
+from unittest.mock import patch
+
 import aiohttp
 from aiohttp import web
 from pytest_aiohttp import AiohttpClient
@@ -91,3 +94,20 @@ async def test_query_user_success(
         assert isinstance(user_resp, UserQueryByIdVO)
         assert user_resp.success
         assert user_resp.user_name == "test-user"
+
+
+def test_missing_socketio_graceful_handling() -> None:
+    """Test that missing optional python-socketio dependency does not break supernote.client imports."""
+    # Simulate missing socketio module using patch.dict
+    with patch.dict("sys.modules", {"socketio": None}):
+        # Re-import supernote.client.socket and supernote.client
+        if "supernote.client.socket" in sys.modules:
+            del sys.modules["supernote.client.socket"]
+        if "supernote.client" in sys.modules:
+            del sys.modules["supernote.client"]
+
+        import supernote.client  # noqa: PLC0415
+        import supernote.client.api  # noqa: PLC0415
+
+        assert supernote.client.Supernote is not None
+        assert supernote.client.Client is not None


### PR DESCRIPTION
## Description

 is defined under optional dependencies ().
However,  unconditionally imported , which executed  at package load time.
When downstream projects (e.g., `home-assistant-supernote-cloud`) import  or  without  installed, importing failed with:
`ModuleNotFoundError: No module named 'socketio'`.

## Changes

- Guard  in `supernote/client/__init__.py` inside a `try...except ImportError` block.
- Guard `import socketio` in `supernote/client/socket.py` and raise a clear `SupernoteSocketError` in `SupernoteSocketClient.__init__` if initialized without `python-socketio`.
- Add unit test `test_missing_socketio_graceful_handling` in `tests/client/test_api.py`.