### PR TITLE
feat(server): add ical dependency and ICalExportService VTODO converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ server = [
   "starlette>=0.35.0",
   "prometheus-client>=0.20.0",
   "python-socketio>=5.11.0",
+  "ical>=8.0.0",
 ]
 all = ["supernote[client,server]"]
 

--- a/supernote/server/services/ical_export.py
+++ b/supernote/server/services/ical_export.py
@@ -1,0 +1,158 @@
+"""iCalendar export service for converting tasks into RFC 5545 VTODO feeds."""
+
+import binascii
+import logging
+from datetime import datetime, timezone
+
+from ical.calendar import Calendar
+from ical.calendar_stream import IcsCalendarStream
+from ical.exceptions import CalendarParseError
+from ical.todo import Todo, TodoStatus
+from ical.types import Recur
+
+from supernote.models.schedule import ScheduleTaskInfo, ScheduleTaskLinkDTO
+from supernote.server.db.models.schedule import ScheduleTaskDO
+from supernote.server.db.session import DatabaseSessionManager
+from supernote.server.services.schedule import ScheduleService
+
+logger = logging.getLogger(__name__)
+
+
+def ms_to_datetime(ms: int | None) -> datetime | None:
+    """Convert epoch milliseconds timestamp to a UTC aware datetime object."""
+    if not ms or ms <= 0:
+        return None
+    return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+
+
+def map_importance_to_priority(importance: str | None) -> int | None:
+    """Map Supernote task importance to RFC 5545 priority (1-9)."""
+    if not importance:
+        return None
+    imp_lower = str(importance).lower()
+    if imp_lower in ("high", "1"):
+        return 1
+    if imp_lower in ("normal", "medium", "5"):
+        return 5
+    if imp_lower in ("low", "9"):
+        return 9
+    return None
+
+
+def format_task_description(detail: str | None, links_b64: str | None) -> str | None:
+    """Combine task detail text with formatted document deep link info."""
+    parts: list[str] = []
+    if detail:
+        parts.append(detail)
+
+    if links_b64:
+        try:
+            link = ScheduleTaskLinkDTO.from_b64(links_b64)
+            link_info = (
+                f"\n--- Supernote Document Link ---\n"
+                f"App: {link.app_name}\n"
+                f"Path: {link.path}\n"
+                f"Page: {link.page}"
+            )
+            parts.append(link_info)
+        except (ValueError, TypeError, binascii.Error) as err:
+            logger.warning("Failed to decode task link base64: %s", err)
+
+    return "\n".join(parts) if parts else None
+
+
+def task_to_vtodo(
+    task: ScheduleTaskDO | ScheduleTaskInfo,
+    group_title: str | None = None,
+) -> Todo:
+    """Convert a Supernote schedule task object to an ical.todo.Todo object."""
+    task_id = str(task.task_id) if task.task_id is not None else "unknown"
+    uid = f"supernote-task-{task_id}@supernote"
+
+    # Status mapping
+    status_str = task.status or "needsAction"
+    completed_dt = ms_to_datetime(task.completed_time)
+
+    if status_str == "completed" or completed_dt is not None:
+        todo_status = TodoStatus.COMPLETED
+    else:
+        todo_status = TodoStatus.NEEDS_ACTION
+
+    due_dt = ms_to_datetime(task.due_time)
+    created_dt = ms_to_datetime(getattr(task, "create_time", None))
+
+    last_mod_ms = getattr(task, "last_modified", None) or getattr(
+        task, "update_time", None
+    )
+    last_mod_dt = ms_to_datetime(last_mod_ms)
+
+    description = format_task_description(
+        task.detail,
+        getattr(task, "links", None),
+    )
+
+    # Recurrence rule
+    recurrence_str = task.recurrence
+    rrule_obj = None
+    if recurrence_str:
+        try:
+            rrule_obj = Recur.from_rrule(recurrence_str)
+        except (ValueError, TypeError, AttributeError, CalendarParseError) as err:
+            logger.warning(
+                "Failed to parse recurrence rule '%s': %s", recurrence_str, err
+            )
+
+    # Categories (Task Group Title)
+    categories = [group_title] if group_title else None
+
+    return Todo(
+        uid=uid,
+        summary=task.title or "",
+        description=description,
+        status=todo_status,
+        due=due_dt,
+        completed=completed_dt if todo_status == TodoStatus.COMPLETED else None,
+        created=created_dt,
+        last_modified=last_mod_dt,
+        categories=categories,
+        rrule=rrule_obj,
+        priority=map_importance_to_priority(task.importance),
+    )
+
+
+class ICalExportService:
+    """Service for exporting Supernote tasks to RFC 5545 iCalendar feeds."""
+
+    def __init__(
+        self,
+        session_manager: DatabaseSessionManager,
+        schedule_service: ScheduleService,
+    ):
+        """Initialize the iCal export service."""
+        self.session_manager = session_manager
+        self.schedule_service = schedule_service
+
+    async def export_calendar(
+        self,
+        user_id: int,
+        task_list_id: int | None = None,
+    ) -> str:
+        """Export user tasks to an RFC 5545 compliant iCalendar (.ics) string."""
+        # 1. Fetch group titles map
+        groups = await self.schedule_service.list_groups(user_id)
+        groups_map = {g.task_list_id: g.title for g in groups}
+
+        # 2. Fetch tasks for user
+        tasks = await self.schedule_service.list_tasks(user_id, group_id=task_list_id)
+
+        # 3. Build iCalendar object
+        calendar = Calendar()
+        for task in tasks:
+            group_title = (
+                groups_map.get(task.task_list_id) if task.task_list_id else None
+            )
+            todo = task_to_vtodo(task, group_title=group_title)
+            calendar.todos.append(todo)
+
+        # 4. Serialize to iCalendar stream
+        return IcsCalendarStream.calendar_to_ics(calendar)

--- a/tests/server/services/test_ical_export.py
+++ b/tests/server/services/test_ical_export.py
@@ -1,0 +1,113 @@
+"""Unit tests for ICalExportService task conversion and iCalendar stream export."""
+
+import pytest
+from ical.calendar_stream import IcsCalendarStream
+
+from supernote.server.db.session import DatabaseSessionManager
+from supernote.server.services.ical_export import ICalExportService
+from supernote.server.services.schedule import ScheduleService
+
+
+@pytest.fixture
+async def schedule_service(session_manager: DatabaseSessionManager) -> ScheduleService:
+    """Fixture for ScheduleService."""
+    return ScheduleService(session_manager)
+
+
+@pytest.fixture
+async def ical_export_service(
+    session_manager: DatabaseSessionManager,
+    schedule_service: ScheduleService,
+) -> ICalExportService:
+    """Fixture for ICalExportService."""
+    return ICalExportService(session_manager, schedule_service)
+
+
+async def test_export_empty_calendar(
+    ical_export_service: ICalExportService,
+) -> None:
+    """Test exporting a calendar when the user has no schedule tasks."""
+    user_id = 999
+    ics_text = await ical_export_service.export_calendar(user_id)
+
+    assert "BEGIN:VCALENDAR" in ics_text
+    assert "END:VCALENDAR" in ics_text
+
+    # Round-trip parsing with ical library
+    calendar = IcsCalendarStream.calendar_from_ics(ics_text)
+    assert calendar is not None
+    assert len(calendar.todos) == 0
+
+
+async def test_export_calendar_tasks_roundtrip(
+    schedule_service: ScheduleService,
+    ical_export_service: ICalExportService,
+) -> None:
+    """Test creating tasks and verifying iCal export round-trip parsing."""
+    user_id = 888
+    group = await schedule_service.create_group(user_id, "Project Alpha")
+    group_id = group.task_list_id
+
+    # Create test tasks
+    task1 = await schedule_service.create_task(
+        user_id=user_id,
+        group_id=group_id,
+        title="Review PR #42",
+        detail="Check iCal export implementation",
+        status="needsAction",
+        importance="high",
+        due_time=1722643200000,
+    )
+    task2 = await schedule_service.create_task(
+        user_id=user_id,
+        group_id=group_id,
+        title="Deploy to Staging",
+        detail="Run schema migrations first",
+        status="completed",
+    )
+    await schedule_service.update_task(
+        user_id, task2.task_id, completed_time=1722646800000
+    )
+
+    # Export calendar for user
+    ics_text = await ical_export_service.export_calendar(user_id)
+    assert isinstance(ics_text, str)
+    assert "BEGIN:VCALENDAR" in ics_text
+    assert "BEGIN:VTODO" in ics_text
+
+    # Parse exported iCal stream back into Calendar object
+    calendar = IcsCalendarStream.calendar_from_ics(ics_text)
+    assert calendar is not None
+    assert len(calendar.todos) == 2
+
+    # Verify task properties match created tasks
+    summaries = {todo.summary for todo in calendar.todos}
+    assert "Review PR #42" in summaries
+    assert "Deploy to Staging" in summaries
+
+    todo1 = next(t for t in calendar.todos if t.summary == "Review PR #42")
+    assert todo1.description == "Check iCal export implementation"
+    assert todo1.categories == ["Project Alpha"]
+    assert todo1.priority == 1
+    assert todo1.uid == f"supernote-task-{task1.task_id}@supernote"
+
+
+async def test_export_calendar_task_list_filtering(
+    schedule_service: ScheduleService,
+    ical_export_service: ICalExportService,
+) -> None:
+    """Test exporting calendar filtered by a specific task list/group."""
+    user_id = 777
+    group_a = await schedule_service.create_group(user_id, "Work")
+    group_b = await schedule_service.create_group(user_id, "Personal")
+
+    await schedule_service.create_task(user_id, group_a.task_list_id, "Work Task")
+    await schedule_service.create_task(user_id, group_b.task_list_id, "Personal Task")
+
+    # Export only Group A
+    ics_text_a = await ical_export_service.export_calendar(
+        user_id, task_list_id=group_a.task_list_id
+    )
+    calendar_a = IcsCalendarStream.calendar_from_ics(ics_text_a)
+    assert len(calendar_a.todos) == 1
+    assert calendar_a.todos[0].summary == "Work Task"

--- a/uv.lock
+++ b/uv.lock
@@ -593,6 +593,20 @@ wheels = [
 ]
 
 [[package]]
+name = "ical"
+version = "14.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/0e/8cdeb5e10f5ab7290d8affe256d1373635d33856b98a27688795d3b0f314/ical-14.0.1.tar.gz", hash = "sha256:444df95a8eb710d87a196fd995b26f0ff7fcf8f779e9eeae898b4393a492be6d", size = 152807, upload-time = "2026-07-19T21:20:28.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/c6/3cc02d2bebf838126b4d3bed4800b108079a3e82cd39f2374bc6256733c6/ical-14.0.1-py3-none-any.whl", hash = "sha256:02ca21f76a7899dbc093b301d2fd2ce2a36c06a9a53e2cec442d80210724737f", size = 141213, upload-time = "2026-07-19T21:20:26.557Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1155,6 +1169,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-engineio"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1369,6 +1395,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1465,6 +1500,7 @@ all = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "google-genai" },
+    { name = "ical" },
     { name = "mashumaro" },
     { name = "mcp" },
     { name = "prometheus-client" },
@@ -1491,6 +1527,7 @@ server = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "google-genai" },
+    { name = "ical" },
     { name = "mashumaro" },
     { name = "mcp" },
     { name = "prometheus-client" },
@@ -1512,6 +1549,7 @@ requires-dist = [
     { name = "alembic", marker = "extra == 'server'", specifier = ">=1.13.0" },
     { name = "colour", specifier = ">=0.1.5" },
     { name = "google-genai", marker = "extra == 'server'", specifier = ">=1.57.0" },
+    { name = "ical", marker = "extra == 'server'", specifier = ">=8.0.0" },
     { name = "mashumaro", marker = "extra == 'client'", specifier = ">=3.17" },
     { name = "mashumaro", marker = "extra == 'server'", specifier = ">=3.17" },
     { name = "mcp", marker = "extra == 'server'", specifier = ">=2.0.0" },
@@ -1592,6 +1630,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds `ical` dependency and implements `ICalExportService` to convert Supernote task records (`ScheduleTaskDO`) into standard RFC 5545 `VTODO` iCalendar format.

Relates to #161, #108