### PR TITLE
feat(server): implement GET /api/schedule/feed.ics endpoint and client SDK helper

### DIFF
--- a/docs/schedule_api.md
+++ b/docs/schedule_api.md
@@ -1,0 +1,107 @@
+# Schedule & Task API Specification and Behavioral Guide
+
+This document defines the architecture, endpoint specifications, data models, and behavioral requirements for the **Schedule & Task Ecosystem** in the Supernote Private Cloud.
+
+---
+
+## 1. Overview & Core Concepts
+
+The Schedule ecosystem manages user tasks, task lists (groups), recurrence rules, and sort orders for both physical Supernote hardware tablets (Nomad, A5X, A6X) and client applications (Web UI, Python SDK).
+
+### Primary Entities
+
+1. **Task Groups (`ScheduleTaskGroupDO` / `t_schedule_task_group`)**
+   * Logical containers/lists for tasks (e.g., "Inbox", "Work", "Personal").
+   * Primary key: `taskListId` (String UUID / Unique Hash).
+
+2. **Tasks (`ScheduleTaskDO` / `t_schedule_task`)**
+   * Individual action items with summary (`title`), details (`detail`), RFC 5545 status (`needsAction`, `completed`), due dates (`dueTime`), completion timestamps (`completedTime`), and optional page links (`links`).
+   * Primary key: `taskId` (String UUID / Unique Hash).
+
+3. **Recurrence Exception Instances (`ScheduleRecurTaskDO` / `t_schedule_recur_task`)**
+   * Specific date/instance overrides for recurring task series.
+   * Linked via `recurrenceId` -> `parent.taskId`.
+
+4. **Task Sort Configurations (`ScheduleSortDO` / `t_schedule_sort`)**
+   * Stores user-defined ordering indexes (`sort`, `sortCompleted`, `planerSort`, `allSort`).
+
+---
+
+## 2. Official Device & Server API Endpoints
+
+All schedule endpoints are unified under the `/api/file/schedule/` namespace (verified against original Java controller `F_ScheduleController`):
+
+### Task Group Management (`/api/file/schedule/group*`)
+* `POST /api/file/schedule/group` — Create Task Group ([AddScheduleTaskGroupDTO](../supernote/models/schedule.py#L180-L203) → [AddScheduleTaskGroupVO](../supernote/models/schedule.py#L479-L490))
+* `PUT /api/file/schedule/group` — Update Task Group ([UpdateScheduleTaskGroupDTO](../supernote/models/schedule.py#L205-L221))
+* `DELETE /api/file/schedule/group/{taskListId}` — Delete Task Group
+* `POST /api/file/schedule/group/clear` — Clear Task Group (soft-deletes all tasks in list)
+* `GET /api/file/schedule/group/{taskListId}` — Get Task Group
+* `POST /api/file/schedule/group/all` — List All Task Groups ([ScheduleTaskGroupDTO](../supernote/models/schedule.py#L238-L254) → [ScheduleTaskGroupVO](../supernote/models/schedule.py#L520-L532))
+
+### Task Operations (`/api/file/schedule/task*`)
+* `POST /api/file/schedule/task` — Create/Upsert Single Task ([AddScheduleTaskDTO](../supernote/models/schedule.py#L258-L327) → [AddScheduleTaskVO](../supernote/models/schedule.py#L535-L545))
+* `PUT /api/file/schedule/task` — Update Single Task ([UpdateScheduleTaskDTO](../supernote/models/schedule.py#L330-L396))
+* `PUT /api/file/schedule/task/list` — **Batch Update Tasks** ([UpdateScheduleTaskListDTO](../supernote/models/schedule.py#L400-L416))
+* `DELETE /api/file/schedule/task/{taskId}` — Delete Task
+* `GET /api/file/schedule/task/{taskId}` — Get Task Details ([ScheduleTaskVO](../supernote/models/schedule.py#L558-L624))
+* `POST /api/file/schedule/task/all` — List All Tasks ([ScheduleTaskDTO](../supernote/models/schedule.py#L419-L438) → [ScheduleTaskAllVO](../supernote/models/schedule.py#L627-L642))
+
+### Sort Configurations (`/api/file/schedule/sort*`)
+* `POST /api/file/schedule/sort` — Add Sort Config ([ScheduleSortDTO](../supernote/models/schedule.py#L441-L461))
+* `PUT /api/file/schedule/sort` — Update Sort Config
+* `DELETE /api/file/schedule/sort/{taskListId}` — Delete Sort Config
+* `POST /api/file/query/schedule/sort` — Query Sort Config ([GetScheduleSortDTO](../supernote/models/schedule.py#L464-L477) → [GetScheduleSortVO](../supernote/models/schedule.py#L645-L663))
+
+### iCalendar Feed Subscriptions (`/api/schedule/feed.ics`)
+* `GET /api/schedule/feed.ics` — Export user tasks in RFC 5545 `VTODO` iCalendar format (`text/calendar`) for calendar app subscriptions (Apple Reminders, Google Calendar, Outlook, Todoist). Accepts authentication via `x-access-token` header or `?token=` query parameter, with optional task list filtering via `?taskListId=`.
+
+---
+
+## 3. Mandatory Behavioral Requirements & Semantics
+
+Implementing compliant Schedule service handlers requires enforcing the following behavioral contracts:
+
+### A. Task & Group ID Generation
+* **Client-Supplied IDs**: Physical tablets and clients supply their own string UUIDs for `taskId` and `taskListId`.
+* **Server Fallback Requirement**: If `taskId` or `taskListId` is omitted/empty during creation:
+  1. The server MUST auto-generate a unique string key (e.g., hash of `title + timestamp`).
+  2. If the generated ID collides with an existing record, the server MUST handle collisions (e.g., appending incrementing suffixes) until a unique ID is assigned.
+
+### B. All-or-Nothing Atomic Batch Guarantee (`PUT /api/file/schedule/task/list`)
+* `updateScheduleTaskList` accepts a list of task updates.
+* **Transactional Rule**: The batch operation **MUST be atomic (all-or-nothing)**. If *any single task ID* in the batch list does not exist in the database, the server MUST roll back the entire transaction and return error `E0329` ("Task does not exist"). Partial batch updates are prohibited.
+
+### C. Cascade Soft-Deletes
+* **Group Deletion**: Deleting a task group (`DELETE /api/file/schedule/group/{taskListId}`) MUST soft-delete (`is_deleted = 'Y'`) the group record AND automatically soft-delete all child tasks sharing that `taskListId`.
+* **Group Clearing**: Clearing a group (`POST /api/file/schedule/group/clear`) MUST update the group's `lastModified` timestamp and soft-delete all tasks under that `taskListId` while leaving the group active.
+* **Parent-Recurrence Soft-Delete**: Soft-deleting a parent task MUST soft-delete all linked recurrence instance overrides in `t_schedule_recur_task` (`recurrence_id = parent_task_id`).
+
+### D. Foreign Key Validation & Default Values
+* **Group Existence**: When creating or updating a task with a non-empty `taskListId`, the server MUST verify that the target task group exists. If missing, return error `E0328` ("Task list group does not exist").
+* **Default Values**:
+  * `isReminderOn` defaults to `"N"` if omitted.
+  * `dueTime` defaults to `0` (Epoch MS) if omitted.
+  * `isDeleted` defaults to `"N"` if omitted.
+  * `lastModified` defaults to `0` if omitted.
+
+### E. Real-Time Socket.IO Event Broadcasting
+Every mutating API call (`create`, `update`, `delete`, `clear` on groups, tasks, or sorts) MUST emit a Socket.IO event (`scheduleTaskMessage`) to notify active user hardware sessions to trigger auto-sync.
+
+---
+
+## 4. Client SDK Abstraction Strategy (`ScheduleClient`)
+
+The Python SDK ([supernote/client/schedule.py](../supernote/client/schedule.py)) provides a high-level, Pythonic interface. 
+
+While non-spec `/api/schedule/*` server routes are removed, **the Python SDK method signatures remain clean abstractions**:
+
+| Python SDK Method | Internal Endpoint Target | Transport / Protocol |
+| :--- | :--- | :--- |
+| `create_group(title)` | `POST /api/file/schedule/group` | Add group JSON payload |
+| `list_groups()` | `POST /api/file/schedule/group/all` | Paginated POST query |
+| `delete_group(group_id)` | `DELETE /api/file/schedule/group/{id}` | Path parameter DELETE |
+| `create_task(...)` | `POST /api/file/schedule/task` | Single task DTO |
+| `list_tasks(group_id)` | `POST /api/file/schedule/task/all` | Paginated POST query |
+| `update_task(...)` | `PUT /api/file/schedule/task/list` | Single-item array batch PUT |
+| `delete_task(task_id)` | `DELETE /api/file/schedule/task/{id}` | Path parameter DELETE |

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -215,3 +215,21 @@ class ScheduleClient:
     async def delete_task(self, task_id: int) -> None:
         """Delete a schedule task."""
         await self._client.request("delete", f"/api/file/schedule/task/{task_id}")
+
+    async def get_ical_feed(self, group_id: int | str | None = None) -> str:
+        """Get the iCalendar (.ics) feed for the user's tasks.
+
+        Args:
+            group_id: Optional task list group ID to filter by.
+
+        Returns:
+            str: RFC 5545 iCalendar (.ics) text stream.
+        """
+        params: dict[str, str] = {}
+        if group_id is not None:
+            params["taskListId"] = str(group_id)
+
+        resp = await self._client.request(
+            "get", "/api/schedule/feed.ics", params=params
+        )
+        return await resp.text()

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -26,6 +26,7 @@ from supernote.models.schedule import (
     UpdateScheduleTaskVO,
 )
 from supernote.server.exceptions import SupernoteError
+from supernote.server.services.ical_export import ICalExportService
 from supernote.server.services.schedule import ScheduleService
 
 logger = logging.getLogger(__name__)
@@ -461,3 +462,36 @@ async def delete_sort(request: web.Request) -> web.Response:
 @routes.post("/api/file/query/schedule/sort")
 async def get_sort(request: web.Request) -> web.Response:
     return web.json_response(GetScheduleSortVO(success=True).to_dict())
+
+
+@routes.get("/api/schedule/feed.ics")
+async def get_schedule_feed_ics(request: web.Request) -> web.Response:
+    """Export schedule tasks as RFC 5545 iCalendar VTODO feed (.ics)."""
+    user_email = request["user"]
+    user_service = request.app["user_service"]
+    user_id = await user_service.get_user_id(user_email)
+
+    task_list_id_str = request.query.get("taskListId")
+    task_list_id = (
+        int(task_list_id_str)
+        if task_list_id_str and task_list_id_str.isdigit()
+        else None
+    )
+
+    schedule_service: ScheduleService = request.app["schedule_service"]
+    ical_export_service = ICalExportService(
+        request.app["session_manager"], schedule_service
+    )
+
+    ics_content = await ical_export_service.export_calendar(
+        user_id, task_list_id=task_list_id
+    )
+
+    return web.Response(
+        body=ics_content.encode("utf-8"),
+        content_type="text/calendar",
+        charset="utf-8",
+        headers={
+            "Content-Disposition": 'inline; filename="feed.ics"',
+        },
+    )

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 from aiohttp.test_utils import TestClient
+from ical.calendar_stream import IcsCalendarStream
 
 from supernote.client.auth import AbstractAuth
 from supernote.client.client import Client
@@ -573,4 +574,63 @@ async def test_schedule_delta_sync_flow(authenticated_client: Client) -> None:
     assert sync_token3 is not None
     assert sync_token3 >= sync_token2
 
+    await schedule.delete_group(group_id)
+
+
+async def test_ical_feed_unauthorized(client: TestClient) -> None:
+    """Test GET /api/schedule/feed.ics without authentication returns 401."""
+    resp = await client.get("/api/schedule/feed.ics")
+    assert resp.status == 401
+
+
+async def test_ical_feed_auth_via_header(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Test GET /api/schedule/feed.ics with header authentication."""
+    resp = await client.get("/api/schedule/feed.ics", headers=auth_headers)
+    assert resp.status == 200
+    assert "text/calendar" in resp.headers["Content-Type"]
+    assert "inline; filename=" in resp.headers.get("Content-Disposition", "")
+
+    body = await resp.text()
+    assert body.startswith("BEGIN:VCALENDAR")
+    assert "END:VCALENDAR" in body
+
+
+async def test_ical_feed_content_and_filtering(
+    client: TestClient,
+    authenticated_client: Client,
+    auth_headers: dict[str, str],
+) -> None:
+    """Test creating tasks via ScheduleClient and retrieving feed via HTTP GET."""
+    schedule = ScheduleClient(authenticated_client)
+
+    # Populate data via ScheduleClient
+    group_vo = await schedule.create_group("Sprint Tasks")
+    assert group_vo.task_list_id is not None
+    group_id = int(group_vo.task_list_id)
+
+    task1 = await schedule.create_task(
+        group_id,
+        "Implement ICS Route",
+        detail="Add feed.ics endpoint in schedule routes",
+    )
+    assert task1.task_id is not None
+
+    # Query ICS feed via ScheduleClient SDK
+    ics_content = await schedule.get_ical_feed()
+    calendar = IcsCalendarStream.calendar_from_ics(ics_content)
+    assert calendar is not None
+    assert len(calendar.todos) >= 1
+
+    todo = next(t for t in calendar.todos if t.summary == "Implement ICS Route")
+    assert todo.description == "Add feed.ics endpoint in schedule routes"
+
+    # Filter by taskListId query param via ScheduleClient SDK
+    filtered_content = await schedule.get_ical_feed(group_id=group_id)
+    filtered_calendar = IcsCalendarStream.calendar_from_ics(filtered_content)
+    assert len(filtered_calendar.todos) == 1
+
+    # Cleanup
     await schedule.delete_group(group_id)


### PR DESCRIPTION
Implements the `GET /api/schedule/feed.ics` HTTP route, token authentication via `?token=` URL parameter, and `ScheduleClient.get_ical_feed()` in the Python SDK. Also documents the endpoint in `docs/schedule_api.md`.

Relates to #161, #108