### PR TITLE
refactor(server): change task_id and task_list_id database schema to String UUIDs

### DIFF
--- a/supernote/alembic/versions/c9a8b7c6d5e4_change_schedule_ids_to_string.py
+++ b/supernote/alembic/versions/c9a8b7c6d5e4_change_schedule_ids_to_string.py
@@ -1,0 +1,36 @@
+"""change schedule task and group ids to string
+
+Revision ID: c9a8b7c6d5e4
+Revises: b8e9c0d1e2f3
+Create Date: 2026-08-17 00:22:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9a8b7c6d5e4"
+down_revision: Union[str, None] = "b8e9c0d1e2f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("t_schedule_task_group") as batch_op:
+        batch_op.alter_column("task_list_id", type_=sa.String(), existing_type=sa.BigInteger())
+
+    with op.batch_alter_table("t_schedule_task") as batch_op:
+        batch_op.alter_column("task_id", type_=sa.String(), existing_type=sa.BigInteger())
+        batch_op.alter_column("task_list_id", type_=sa.String(), existing_type=sa.BigInteger())
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("t_schedule_task") as batch_op:
+        batch_op.alter_column("task_list_id", type_=sa.BigInteger(), existing_type=sa.String())
+        batch_op.alter_column("task_id", type_=sa.BigInteger(), existing_type=sa.String())
+
+    with op.batch_alter_table("t_schedule_task_group") as batch_op:
+        batch_op.alter_column("task_list_id", type_=sa.BigInteger(), existing_type=sa.String())

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -38,13 +38,13 @@ class ScheduleClient:
             "/api/file/schedule/group", AddScheduleTaskGroupVO, json=dto.to_dict()
         )
 
-    async def get_group(self, group_id: int) -> GetScheduleTaskGroupVO:
+    async def get_group(self, group_id: int | str) -> GetScheduleTaskGroupVO:
         """Get a schedule group by ID."""
         return await self._client.get_json(
             f"/api/file/schedule/group/{group_id}", GetScheduleTaskGroupVO
         )
 
-    async def update_group(self, group_id: int, title: str) -> BaseResponse:
+    async def update_group(self, group_id: int | str, title: str) -> BaseResponse:
         """Update a schedule group."""
         dto = UpdateScheduleTaskGroupDTO(
             task_list_id=str(group_id),
@@ -55,7 +55,7 @@ class ScheduleClient:
             "/api/file/schedule/group", BaseResponse, json=dto.to_dict()
         )
 
-    async def clear_group(self, group_id: int) -> BaseResponse:
+    async def clear_group(self, group_id: int | str) -> BaseResponse:
         """Clear all tasks within a schedule group."""
         dto = ClearScheduleTaskGroupDTO(
             task_list_id=str(group_id), last_modified=int(time.time() * 1000)
@@ -87,13 +87,13 @@ class ScheduleClient:
             if not page_token:
                 break
 
-    async def delete_group(self, group_id: int) -> None:
+    async def delete_group(self, group_id: int | str) -> None:
         """Delete a schedule group."""
         await self._client.request("delete", f"/api/file/schedule/group/{group_id}")
 
     async def create_task(
         self,
-        group_id: int,
+        group_id: int | str,
         title: str,
         detail: str | None = None,
         status: str | None = None,
@@ -129,7 +129,7 @@ class ScheduleClient:
             "/api/file/schedule/task", AddScheduleTaskVO, json=dto.to_dict()
         )
 
-    async def get_task(self, task_id: int) -> ScheduleTaskVO:
+    async def get_task(self, task_id: int | str) -> ScheduleTaskVO:
         """Get details for a single task."""
         return await self._client.get_json(
             f"/api/file/schedule/task/{task_id}", ScheduleTaskVO
@@ -153,7 +153,7 @@ class ScheduleClient:
 
     async def list_tasks(
         self,
-        group_id: int | None = None,
+        group_id: int | str | None = None,
         since: int | None = None,
     ) -> AsyncIterator[ScheduleTaskInfo]:
         """List all schedule tasks, automatically iterating through all pages.
@@ -181,7 +181,7 @@ class ScheduleClient:
 
     async def update_task(
         self,
-        task_id: int,
+        task_id: int | str,
         title: str,
         detail: str | None = None,
         status: str | None = None,
@@ -189,7 +189,7 @@ class ScheduleClient:
         due_time: int | None = None,
         recurrence: str | None = None,
         is_reminder_on: bool | None = None,
-        task_list_id: int | None = None,
+        task_list_id: int | str | None = None,
     ) -> UpdateScheduleTaskVO:
         """Update a task using DTO."""
         is_reminder_on_value: BooleanEnum | None = None
@@ -212,7 +212,7 @@ class ScheduleClient:
             "/api/file/schedule/task", UpdateScheduleTaskVO, json=dto.to_dict()
         )
 
-    async def delete_task(self, task_id: int) -> None:
+    async def delete_task(self, task_id: int | str) -> None:
         """Delete a schedule task."""
         await self._client.request("delete", f"/api/file/schedule/task/{task_id}")
 

--- a/supernote/server/db/models/schedule.py
+++ b/supernote/server/db/models/schedule.py
@@ -7,17 +7,20 @@ from supernote.server.db.base import Base
 from supernote.server.utils.unique_id import next_id
 
 
+def generate_id_string() -> str:
+    """Generate default unique ID as string."""
+    return str(next_id())
+
+
 class ScheduleTaskGroupDO(Base):
     """Groups of tasks (e.g., 'Inbox', 'Work', 'Personal')."""
 
     __tablename__ = "t_schedule_task_group"
 
-    # In legacy/docs, task_list_id might be a string (UUID) or Int.
-    # Using unique_id Int for consistency, but mapping to String if API requires it.
-    task_list_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, default=next_id
+    task_list_id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=generate_id_string
     )
-    """Unique ID."""
+    """Unique ID string."""
 
     user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
     """User ID."""
@@ -36,10 +39,12 @@ class ScheduleTaskDO(Base):
 
     __tablename__ = "t_schedule_task"
 
-    task_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, default=next_id)
-    """Unique ID."""
+    task_id: Mapped[str] = mapped_column(
+        String, primary_key=True, default=generate_id_string
+    )
+    """Unique ID string."""
 
-    task_list_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
+    task_list_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
     """Link back to task list."""
 
     user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -35,18 +35,6 @@ logger = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
 
-def _parse_id_to_int(val: Any) -> int:
-    """Safely parse integer ID or deterministically convert string UUID to integer ID."""
-    if isinstance(val, int):
-        return val
-    if not val:
-        return 0
-    val_str = str(val).strip()
-    if val_str.isdigit() or (val_str.startswith("-") and val_str[1:].isdigit()):
-        return int(val_str)
-    return int(hashlib.md5(val_str.encode("utf-8")).hexdigest()[:15], 16) & 0x7FFFFFFFFFFFFFFF
-
-
 def _extract_task_updates(dto: UpdateScheduleTaskDTO) -> dict[str, Any]:
     """Extract populated update fields from UpdateScheduleTaskDTO into a service dict."""
     updates: dict[str, Any] = {}
@@ -56,7 +44,7 @@ def _extract_task_updates(dto: UpdateScheduleTaskDTO) -> dict[str, Any]:
         val = getattr(dto, f.name)
         if val is not None:
             if f.name == "task_list_id":
-                updates["task_list_id"] = _parse_id_to_int(val)
+                updates["task_list_id"] = str(val)
             elif f.name == "is_reminder_on":
                 updates["is_reminder_on"] = val == BooleanEnum.YES
             else:
@@ -103,7 +91,7 @@ async def update_group(request: web.Request) -> web.Response:
         user_id = await request.app["user_service"].get_user_id(user)
 
         group = await schedule_service.update_group(
-            user_id, _parse_id_to_int(dto.task_list_id), dto.title
+            user_id, str(dto.task_list_id), dto.title
         )
         if not group:
             raise SupernoteError("Not found", status_code=404)
@@ -123,7 +111,7 @@ async def delete_group(request: web.Request) -> web.Response:
         if not group_id_str:
             raise SupernoteError("Missing taskListId", status_code=400)
 
-        group_id = _parse_id_to_int(group_id_str)
+        group_id = str(group_id_str)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -150,7 +138,7 @@ async def get_group(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        group = await schedule_service.get_group(user_id, _parse_id_to_int(group_id_str))
+        group = await schedule_service.get_group(user_id, str(group_id_str))
         if not group:
             raise SupernoteError("Not found", status_code=404)
 
@@ -179,7 +167,7 @@ async def clear_group(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        await schedule_service.clear_group_tasks(user_id, _parse_id_to_int(dto.task_list_id))
+        await schedule_service.clear_group_tasks(user_id, str(dto.task_list_id))
         return web.json_response(BaseResponse(success=True).to_dict())
     except SupernoteError as err:
         return err.to_response()
@@ -226,7 +214,7 @@ async def create_task(request: web.Request) -> web.Response:
         if not dto.title:
             raise SupernoteError("Title is required", status_code=400)
 
-        group_id = _parse_id_to_int(dto.task_list_id) if dto.task_list_id else 0
+        group_id = str(dto.task_list_id) if dto.task_list_id else "0"
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
@@ -252,7 +240,7 @@ async def create_task(request: web.Request) -> web.Response:
             sort_time=dto.sort_time,
             planer_sort_time=dto.planer_sort_time,
             all_sort_time=dto.all_sort_time,
-            task_id=_parse_id_to_int(dto.task_id) if dto.task_id else None,
+            task_id=str(dto.task_id) if dto.task_id else None,
         )
         task_id_resp = str(task.task_id)
         return web.json_response(
@@ -274,7 +262,7 @@ async def update_task(request: web.Request) -> web.Response:
         if not dto.task_id:
             raise SupernoteError("Missing taskId", status_code=400)
 
-        task_id = _parse_id_to_int(dto.task_id)
+        task_id = str(dto.task_id)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -309,7 +297,7 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
         for item in dto.update_schedule_task_list:
             if item.task_id:
                 item_updates = _extract_task_updates(item)
-                item_updates["task_id"] = _parse_id_to_int(item.task_id)
+                item_updates["task_id"] = str(item.task_id)
                 updates_list.append(item_updates)
 
         await schedule_service.batch_update_tasks(user_id, updates_list)
@@ -329,7 +317,7 @@ async def delete_task(request: web.Request) -> web.Response:
         if not task_id_str:
             raise SupernoteError("Missing taskId", status_code=400)
 
-        task_id = _parse_id_to_int(task_id_str)
+        task_id = str(task_id_str)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -356,7 +344,7 @@ async def get_task(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        task = await schedule_service.get_task(user_id, _parse_id_to_int(task_id_str))
+        task = await schedule_service.get_task(user_id, str(task_id_str))
         if not task:
             raise SupernoteError("Not found", status_code=404)
 
@@ -400,7 +388,7 @@ async def list_tasks(request: web.Request) -> web.Response:
         except Exception:
             data = {}
         dto = ScheduleTaskDTO.from_dict(data)
-        group_id = _parse_id_to_int(dto.task_list_id) if dto.task_list_id else None
+        group_id = str(dto.task_list_id) if dto.task_list_id else None
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
@@ -486,7 +474,7 @@ async def get_schedule_feed_ics(request: web.Request) -> web.Response:
 
     task_list_id_str = request.query.get("taskListId")
     task_list_id = (
-        _parse_id_to_int(task_list_id_str)
+        str(task_list_id_str)
         if task_list_id_str
         else None
     )

--- a/supernote/server/services/ical_export.py
+++ b/supernote/server/services/ical_export.py
@@ -135,7 +135,7 @@ class ICalExportService:
     async def export_calendar(
         self,
         user_id: int,
-        task_list_id: int | None = None,
+        task_list_id: str | None = None,
     ) -> str:
         """Export user tasks to an RFC 5545 compliant iCalendar (.ics) string."""
         # 1. Fetch group titles map

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -76,7 +76,7 @@ class ScheduleService:
             return list(result.scalars().all())
 
     async def get_group(
-        self, user_id: int, group_id: int
+        self, user_id: int, group_id: str
     ) -> ScheduleTaskGroupDO | None:
         """Get a task group by ID."""
         async with self.session_manager.session() as session:
@@ -88,7 +88,7 @@ class ScheduleService:
             return result.scalar_one_or_none()
 
     async def update_group(
-        self, user_id: int, group_id: int, title: str
+        self, user_id: int, group_id: str, title: str
     ) -> ScheduleTaskGroupDO | None:
         """Update a task group title."""
         if len(title) > MAX_TITLE_LENGTH:
@@ -114,7 +114,7 @@ class ScheduleService:
             result = await session.execute(stmt_get)
             return result.scalar_one_or_none()
 
-    async def delete_group(self, user_id: int, group_id: int) -> bool:
+    async def delete_group(self, user_id: int, group_id: str) -> bool:
         """Delete a task group and cascade delete all contained tasks."""
         async with self.session_manager.session() as session:
             # First cascade delete all tasks in the group
@@ -134,7 +134,7 @@ class ScheduleService:
 
             return bool(getattr(result, "rowcount", 0) > 0)
 
-    async def clear_group_tasks(self, user_id: int, group_id: int) -> bool:
+    async def clear_group_tasks(self, user_id: int, group_id: str) -> bool:
         """Clear all tasks from a task group without deleting the group."""
         async with self.session_manager.session() as session:
             stmt = delete(ScheduleTaskDO).where(
@@ -150,7 +150,7 @@ class ScheduleService:
     async def create_task(
         self,
         user_id: int,
-        group_id: int,
+        group_id: str,
         title: str,
         detail: str = "",
         status: str = "needsAction",
@@ -167,7 +167,7 @@ class ScheduleService:
         sort_time: int | None = None,
         planer_sort_time: int | None = None,
         all_sort_time: int | None = None,
-        task_id: int | None = None,
+        task_id: str | None = None,
     ) -> ScheduleTaskDO:
         """Create a new task."""
         if len(title) > MAX_TITLE_LENGTH:
@@ -204,7 +204,7 @@ class ScheduleService:
             await session.refresh(task)
             return task
 
-    async def get_task(self, user_id: int, task_id: int) -> ScheduleTaskDO | None:
+    async def get_task(self, user_id: int, task_id: str) -> ScheduleTaskDO | None:
         """Get a task by ID."""
         async with self.session_manager.session() as session:
             stmt = select(ScheduleTaskDO).where(
@@ -217,7 +217,7 @@ class ScheduleService:
     async def list_tasks(
         self,
         user_id: int,
-        group_id: int | None = None,
+        group_id: str | None = None,
         since: int | None = None,
     ) -> list[ScheduleTaskDO]:
         """List tasks for a user, optionally filtered by group and since timestamp."""
@@ -233,7 +233,7 @@ class ScheduleService:
             return list(result.scalars().all())
 
     async def update_task(
-        self, user_id: int, task_id: int, **kwargs: Any
+        self, user_id: int, task_id: str, **kwargs: Any
     ) -> ScheduleTaskDO | None:
         """Update a task."""
         updates = {k: v for k, v in kwargs.items() if k in TASK_ALLOWED_UPDATE_FIELDS}
@@ -296,7 +296,7 @@ class ScheduleService:
             await session.commit()
             return True
 
-    async def delete_task(self, user_id: int, task_id: int) -> bool:
+    async def delete_task(self, user_id: int, task_id: str) -> bool:
         """Delete a task."""
         async with self.session_manager.session() as session:
             stmt = delete(ScheduleTaskDO).where(

--- a/tests/server/db/test_migrations.py
+++ b/tests/server/db/test_migrations.py
@@ -75,7 +75,7 @@ def test_migration_upgrades_successfully(migrated_db: str) -> None:
         # Check if the 'alembic_version' table exists and has the head revision
         result = conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
-        assert version == "b8e9c0d1e2f3"
+        assert version == "c9a8b7c6d5e4"
 
         # Check if a known table exists (e.g. users)
         result = conn.execute(text("SELECT count(*) FROM users"))


### PR DESCRIPTION
## Description

This PR updates the database schema for schedule tasks and task groups to store `task_id` and `task_list_id` natively as `String` columns rather than `BigInteger`.

### Why
- When clients (Partner App / Supernote devices) create tasks, they supply hexadecimal UUID string identifiers (e.g. `'dcf35927c2c7279e3d204f592af6e9ed'`).
- Storing `task_id` and `task_list_id` as `String` in SQLite ensures that the exact client-supplied UUID string is preserved in the database and returned back in `POST /api/file/schedule/task/all` responses.
- Eliminates ID conversion or hashing logic.

### Changes
- Updated `ScheduleTaskGroupDO` and `ScheduleTaskDO` in `supernote/server/db/models/schedule.py` to use `Mapped[str] = mapped_column(String)`.
- Added Alembic migration `c9a8b7c6d5e4_change_schedule_ids_to_string.py`.
- Updated `ScheduleService` and `ScheduleClient` type annotations to `str`.
