### PR TITLE
fix(schedule): fix partner app task sync and socket.io compatibility

### DIFF
--- a/supernote/alembic/versions/d1e2f3a4b5c6_add_client_task_ids.py
+++ b/supernote/alembic/versions/d1e2f3a4b5c6_add_client_task_ids.py
@@ -1,0 +1,50 @@
+"""add client_task_id and client_task_list_id columns to schedule tables
+
+Revision ID: d1e2f3a4b5c6
+Revises: b8e9c0d1e2f3
+Create Date: 2026-08-17 00:47:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, None] = "b8e9c0d1e2f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("t_schedule_task_group") as batch_op:
+        batch_op.add_column(
+            sa.Column("client_task_list_id", sa.String(), nullable=True)
+        )
+        batch_op.create_index(
+            "ix_t_schedule_task_group_client_task_list_id", ["client_task_list_id"]
+        )
+
+    with op.batch_alter_table("t_schedule_task") as batch_op:
+        batch_op.add_column(sa.Column("client_task_id", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column("client_task_list_id", sa.String(), nullable=True)
+        )
+        batch_op.create_index("ix_t_schedule_task_client_task_id", ["client_task_id"])
+        batch_op.create_index(
+            "ix_t_schedule_task_client_task_list_id", ["client_task_list_id"]
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("t_schedule_task") as batch_op:
+        batch_op.drop_index("ix_t_schedule_task_client_task_list_id")
+        batch_op.drop_index("ix_t_schedule_task_client_task_id")
+        batch_op.drop_column("client_task_list_id")
+        batch_op.drop_column("client_task_id")
+
+    with op.batch_alter_table("t_schedule_task_group") as batch_op:
+        batch_op.drop_index("ix_t_schedule_task_group_client_task_list_id")
+        batch_op.drop_column("client_task_list_id")

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -38,13 +38,13 @@ class ScheduleClient:
             "/api/file/schedule/group", AddScheduleTaskGroupVO, json=dto.to_dict()
         )
 
-    async def get_group(self, group_id: int) -> GetScheduleTaskGroupVO:
+    async def get_group(self, group_id: str) -> GetScheduleTaskGroupVO:
         """Get a schedule group by ID."""
         return await self._client.get_json(
             f"/api/file/schedule/group/{group_id}", GetScheduleTaskGroupVO
         )
 
-    async def update_group(self, group_id: int, title: str) -> BaseResponse:
+    async def update_group(self, group_id: str, title: str) -> BaseResponse:
         """Update a schedule group."""
         dto = UpdateScheduleTaskGroupDTO(
             task_list_id=str(group_id),
@@ -55,7 +55,7 @@ class ScheduleClient:
             "/api/file/schedule/group", BaseResponse, json=dto.to_dict()
         )
 
-    async def clear_group(self, group_id: int) -> BaseResponse:
+    async def clear_group(self, group_id: str) -> BaseResponse:
         """Clear all tasks within a schedule group."""
         dto = ClearScheduleTaskGroupDTO(
             task_list_id=str(group_id), last_modified=int(time.time() * 1000)
@@ -87,13 +87,13 @@ class ScheduleClient:
             if not page_token:
                 break
 
-    async def delete_group(self, group_id: int) -> None:
+    async def delete_group(self, group_id: str) -> None:
         """Delete a schedule group."""
         await self._client.request("delete", f"/api/file/schedule/group/{group_id}")
 
     async def create_task(
         self,
-        group_id: int,
+        group_id: str,
         title: str,
         detail: str | None = None,
         status: str | None = None,
@@ -137,7 +137,7 @@ class ScheduleClient:
 
     async def get_tasks_all(
         self,
-        group_id: int | str | None = None,
+        group_id: str | None = None,
         next_sync_token: int | None = None,
         page_token: str | None = None,
     ) -> ScheduleTaskAllVO:
@@ -153,7 +153,7 @@ class ScheduleClient:
 
     async def list_tasks(
         self,
-        group_id: int | None = None,
+        group_id: str | None = None,
         since: int | None = None,
     ) -> AsyncIterator[ScheduleTaskInfo]:
         """List all schedule tasks, automatically iterating through all pages.
@@ -181,7 +181,7 @@ class ScheduleClient:
 
     async def update_task(
         self,
-        task_id: int,
+        task_id: str,
         title: str,
         detail: str | None = None,
         status: str | None = None,
@@ -189,7 +189,7 @@ class ScheduleClient:
         due_time: int | None = None,
         recurrence: str | None = None,
         is_reminder_on: bool | None = None,
-        task_list_id: int | None = None,
+        task_list_id: str | None = None,
     ) -> UpdateScheduleTaskVO:
         """Update a task using DTO."""
         is_reminder_on_value: BooleanEnum | None = None
@@ -212,7 +212,7 @@ class ScheduleClient:
             "/api/file/schedule/task", UpdateScheduleTaskVO, json=dto.to_dict()
         )
 
-    async def delete_task(self, task_id: int) -> None:
+    async def delete_task(self, task_id: str) -> None:
         """Delete a schedule task."""
         await self._client.request("delete", f"/api/file/schedule/task/{task_id}")
 

--- a/supernote/client/schedule.py
+++ b/supernote/client/schedule.py
@@ -47,7 +47,7 @@ class ScheduleClient:
     async def update_group(self, group_id: str, title: str) -> BaseResponse:
         """Update a schedule group."""
         dto = UpdateScheduleTaskGroupDTO(
-            task_list_id=str(group_id),
+            task_list_id=group_id,
             title=title,
             last_modified=int(time.time() * 1000),
         )
@@ -58,7 +58,7 @@ class ScheduleClient:
     async def clear_group(self, group_id: str) -> BaseResponse:
         """Clear all tasks within a schedule group."""
         dto = ClearScheduleTaskGroupDTO(
-            task_list_id=str(group_id), last_modified=int(time.time() * 1000)
+            task_list_id=group_id, last_modified=int(time.time() * 1000)
         )
         return await self._client.post_json(
             "/api/file/schedule/group/clear", BaseResponse, json=dto.to_dict()
@@ -111,7 +111,7 @@ class ScheduleClient:
         """Create a new schedule task."""
         dto = AddScheduleTaskDTO(
             task_id=task_id,
-            task_list_id=str(group_id),
+            task_list_id=group_id,
             title=title,
             detail=detail,
             status=status,
@@ -143,7 +143,7 @@ class ScheduleClient:
     ) -> ScheduleTaskAllVO:
         """Fetch tasks response object including nextSyncToken and scheduleTask items."""
         dto = ScheduleTaskDTO(
-            task_list_id=str(group_id) if group_id is not None else None,
+            task_list_id=group_id,
             next_sync_token=next_sync_token,
             next_page_tokens=page_token,
         )
@@ -197,7 +197,7 @@ class ScheduleClient:
             is_reminder_on_value = BooleanEnum.of(is_reminder_on)
 
         dto = UpdateScheduleTaskDTO(
-            task_id=str(task_id),
+            task_id=task_id,
             title=title,
             detail=detail,
             status=status,
@@ -205,7 +205,7 @@ class ScheduleClient:
             due_time=due_time,
             recurrence=recurrence,
             is_reminder_on=is_reminder_on_value,
-            task_list_id=str(task_list_id) if task_list_id else None,
+            task_list_id=task_list_id,
             last_modified=int(time.time() * 1000),
         )
         return await self._client.put_json(
@@ -216,7 +216,7 @@ class ScheduleClient:
         """Delete a schedule task."""
         await self._client.request("delete", f"/api/file/schedule/task/{task_id}")
 
-    async def get_ical_feed(self, group_id: int | str | None = None) -> str:
+    async def get_ical_feed(self, group_id: str | None = None) -> str:
         """Get the iCalendar (.ics) feed for the user's tasks.
 
         Args:
@@ -227,7 +227,7 @@ class ScheduleClient:
         """
         params: dict[str, str] = {}
         if group_id is not None:
-            params["taskListId"] = str(group_id)
+            params["taskListId"] = group_id
 
         resp = await self._client.request(
             "get", "/api/schedule/feed.ics", params=params

--- a/supernote/server/app.py
+++ b/supernote/server/app.py
@@ -172,7 +172,7 @@ async def socketio_compat_middleware(
 ) -> web.StreamResponse:
     """Rewrite Socket.IO requests query parameters from EIO=3 (Engine.IO v3) to EIO=4 for protocol compatibility."""
     if request.path.startswith("/socket.io/") and request.query.get("EIO") == "3":
-        new_query = request.query.copy()
+        new_query = dict(request.query)
         new_query["EIO"] = "4"
         request = request.clone(rel_url=request.rel_url.with_query(new_query))
     return await handler(request)

--- a/supernote/server/app.py
+++ b/supernote/server/app.py
@@ -166,6 +166,19 @@ async def trace_middleware(
 
 
 @web.middleware
+async def socketio_compat_middleware(
+    request: web.Request,
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
+    """Rewrite Socket.IO requests query parameters from EIO=3 (Engine.IO v3) to EIO=4 for protocol compatibility."""
+    if request.path.startswith("/socket.io/") and request.query.get("EIO") == "3":
+        new_query = request.query.copy()
+        new_query["EIO"] = "4"
+        request = request.clone(rel_url=request.rel_url.with_query(new_query))
+    return await handler(request)
+
+
+@web.middleware
 async def metrics_middleware(
     request: web.Request,
     handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
@@ -435,6 +448,7 @@ def create_app(config: ServerConfig) -> web.Application:
             await aiohttp_remotes.setup(app, aiohttp_remotes.XForwardedRelaxed())
 
         # Register trace and auth middlewares after proxy setup to avoid clone errors
+        app.middlewares.append(socketio_compat_middleware)
         if config.metrics_enabled:
             app.middlewares.append(metrics_middleware)
         app.middlewares.append(trace_middleware)

--- a/supernote/server/db/models/schedule.py
+++ b/supernote/server/db/models/schedule.py
@@ -12,12 +12,15 @@ class ScheduleTaskGroupDO(Base):
 
     __tablename__ = "t_schedule_task_group"
 
-    # In legacy/docs, task_list_id might be a string (UUID) or Int.
-    # Using unique_id Int for consistency, but mapping to String if API requires it.
     task_list_id: Mapped[int] = mapped_column(
         BigInteger, primary_key=True, default=next_id
     )
-    """Unique ID."""
+    """Internal unique integer ID."""
+
+    client_task_list_id: Mapped[str | None] = mapped_column(
+        String, index=True, nullable=True
+    )
+    """Independent external client string ID (e.g. UUID)."""
 
     user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
     """User ID."""
@@ -30,6 +33,11 @@ class ScheduleTaskGroupDO(Base):
     )
     """Creation time in epoch milliseconds."""
 
+    @property
+    def id(self) -> str:
+        """API task list ID: returns client_task_list_id if present, else str(task_list_id)."""
+        return self.client_task_list_id or str(self.task_list_id)
+
 
 class ScheduleTaskDO(Base):
     """Individual Tasks."""
@@ -37,10 +45,30 @@ class ScheduleTaskDO(Base):
     __tablename__ = "t_schedule_task"
 
     task_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, default=next_id)
-    """Unique ID."""
+    """Internal unique integer ID."""
+
+    client_task_id: Mapped[str | None] = mapped_column(
+        String, index=True, nullable=True
+    )
+    """Independent external client task string ID (e.g. UUID)."""
 
     task_list_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
-    """Link back to task list."""
+    """Link back to task list (internal integer ID)."""
+
+    client_task_list_id: Mapped[str | None] = mapped_column(
+        String, index=True, nullable=True
+    )
+    """Independent external client task list string ID."""
+
+    @property
+    def id(self) -> str:
+        """API task ID: returns client_task_id if present, else str(task_id)."""
+        return self.client_task_id or str(self.task_id)
+
+    @property
+    def group_id(self) -> str:
+        """API task list ID: returns client_task_list_id if present, else str(task_list_id)."""
+        return self.client_task_list_id or str(self.task_list_id)
 
     user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
     """User ID."""

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -43,7 +43,7 @@ def _extract_task_updates(dto: UpdateScheduleTaskDTO) -> dict[str, Any]:
         val = getattr(dto, f.name)
         if val is not None:
             if f.name == "task_list_id":
-                updates["task_list_id"] = str(val)
+                updates["task_list_id"] = val
             elif f.name == "is_reminder_on":
                 updates["is_reminder_on"] = val == BooleanEnum.YES
             else:
@@ -66,7 +66,7 @@ async def create_group(request: web.Request) -> web.Response:
         group = await schedule_service.create_group(user_id, dto.title)
         return web.json_response(
             AddScheduleTaskGroupVO(
-                success=True, task_list_id=str(group.task_list_id)
+                success=True, task_list_id=group.id
             ).to_dict()
         )
     except SupernoteError as err:
@@ -90,7 +90,7 @@ async def update_group(request: web.Request) -> web.Response:
         user_id = await request.app["user_service"].get_user_id(user)
 
         group = await schedule_service.update_group(
-            user_id, str(dto.task_list_id), dto.title
+            user_id, dto.task_list_id, dto.title
         )
         if not group:
             raise SupernoteError("Not found", status_code=404)
@@ -106,11 +106,10 @@ async def update_group(request: web.Request) -> web.Response:
 @routes.delete("/api/file/schedule/group/{taskListId}")
 async def delete_group(request: web.Request) -> web.Response:
     try:
-        group_id_str = request.match_info.get("taskListId")
-        if not group_id_str:
+        group_id = request.match_info.get("taskListId")
+        if not group_id:
             raise SupernoteError("Missing taskListId", status_code=400)
 
-        group_id = str(group_id_str)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -129,15 +128,15 @@ async def delete_group(request: web.Request) -> web.Response:
 @routes.get("/api/file/schedule/group/{taskListId}")
 async def get_group(request: web.Request) -> web.Response:
     try:
-        group_id_str = request.match_info.get("taskListId")
-        if not group_id_str:
+        group_id = request.match_info.get("taskListId")
+        if not group_id:
             raise SupernoteError("Missing taskListId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        group = await schedule_service.get_group(user_id, str(group_id_str))
+        group = await schedule_service.get_group(user_id, group_id)
         if not group:
             raise SupernoteError("Not found", status_code=404)
 
@@ -161,12 +160,14 @@ async def clear_group(request: web.Request) -> web.Response:
     try:
         data = await request.json()
         dto = ClearScheduleTaskGroupDTO.from_dict(data)
+        if not dto.task_list_id:
+            raise SupernoteError("Missing taskListId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        await schedule_service.clear_group_tasks(user_id, str(dto.task_list_id))
+        await schedule_service.clear_group_tasks(user_id, dto.task_list_id)
         return web.json_response(BaseResponse(success=True).to_dict())
     except SupernoteError as err:
         return err.to_response()
@@ -213,7 +214,7 @@ async def create_task(request: web.Request) -> web.Response:
         if not dto.title:
             raise SupernoteError("Title is required", status_code=400)
 
-        group_id = str(dto.task_list_id) if dto.task_list_id else "0"
+        group_id = dto.task_list_id or "0"
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
@@ -239,7 +240,7 @@ async def create_task(request: web.Request) -> web.Response:
             sort_time=dto.sort_time,
             planer_sort_time=dto.planer_sort_time,
             all_sort_time=dto.all_sort_time,
-            task_id=str(dto.task_id) if dto.task_id else None,
+            task_id=dto.task_id,
         )
         return web.json_response(
             AddScheduleTaskVO(success=True, task_id=task.id).to_dict()
@@ -260,13 +261,14 @@ async def update_task(request: web.Request) -> web.Response:
         if not dto.task_id:
             raise SupernoteError("Missing taskId", status_code=400)
 
-        task_id = str(dto.task_id)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
         updates = _extract_task_updates(dto)
-        updated_task = await schedule_service.update_task(user_id, task_id, **updates)
+        updated_task = await schedule_service.update_task(
+            user_id, dto.task_id, **updates
+        )
         if not updated_task:
             raise SupernoteError("Not found", status_code=404)
 
@@ -293,7 +295,7 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
         for item in dto.update_schedule_task_list:
             if item.task_id:
                 item_updates = _extract_task_updates(item)
-                item_updates["task_id"] = str(item.task_id)
+                item_updates["task_id"] = item.task_id
                 updates_list.append(item_updates)
 
         await schedule_service.batch_update_tasks(user_id, updates_list)
@@ -309,11 +311,10 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
 @routes.delete("/api/file/schedule/task/{taskId}")
 async def delete_task(request: web.Request) -> web.Response:
     try:
-        task_id_str = request.match_info.get("taskId")
-        if not task_id_str:
+        task_id = request.match_info.get("taskId")
+        if not task_id:
             raise SupernoteError("Missing taskId", status_code=400)
 
-        task_id = str(task_id_str)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -332,15 +333,15 @@ async def delete_task(request: web.Request) -> web.Response:
 @routes.get("/api/file/schedule/task/{taskId}")
 async def get_task(request: web.Request) -> web.Response:
     try:
-        task_id_str = request.match_info.get("taskId")
-        if not task_id_str:
+        task_id = request.match_info.get("taskId")
+        if not task_id:
             raise SupernoteError("Missing taskId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        task = await schedule_service.get_task(user_id, str(task_id_str))
+        task = await schedule_service.get_task(user_id, task_id)
         if not task:
             raise SupernoteError("Not found", status_code=404)
 
@@ -384,7 +385,7 @@ async def list_tasks(request: web.Request) -> web.Response:
         except Exception:
             data = {}
         dto = ScheduleTaskDTO.from_dict(data)
-        group_id = str(dto.task_list_id) if dto.task_list_id else None
+        group_id = dto.task_list_id
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
@@ -468,8 +469,7 @@ async def get_schedule_feed_ics(request: web.Request) -> web.Response:
     user_service = request.app["user_service"]
     user_id = await user_service.get_user_id(user_email)
 
-    task_list_id_str = request.query.get("taskListId")
-    task_list_id = str(task_list_id_str) if task_list_id_str else None
+    task_list_id = request.query.get("taskListId")
 
     schedule_service: ScheduleService = request.app["schedule_service"]
     ical_export_service = ICalExportService(

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -65,9 +65,7 @@ async def create_group(request: web.Request) -> web.Response:
 
         group = await schedule_service.create_group(user_id, dto.title)
         return web.json_response(
-            AddScheduleTaskGroupVO(
-                success=True, task_list_id=group.id
-            ).to_dict()
+            AddScheduleTaskGroupVO(success=True, task_list_id=group.id).to_dict()
         )
     except SupernoteError as err:
         return err.to_response()

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -87,10 +87,9 @@ async def update_group(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        group = await schedule_service.update_group(
+        if not await schedule_service.update_group(
             user_id, dto.task_list_id, dto.title
-        )
-        if not group:
+        ):
             raise SupernoteError("Not found", status_code=404)
         return web.json_response(BaseResponse(success=True).to_dict())
     except SupernoteError as err:
@@ -104,16 +103,14 @@ async def update_group(request: web.Request) -> web.Response:
 @routes.delete("/api/file/schedule/group/{taskListId}")
 async def delete_group(request: web.Request) -> web.Response:
     try:
-        group_id = request.match_info.get("taskListId")
-        if not group_id:
+        if not (group_id := request.match_info.get("taskListId")):
             raise SupernoteError("Missing taskListId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        success = await schedule_service.delete_group(user_id, group_id)
-        if not success:
+        if not await schedule_service.delete_group(user_id, group_id):
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(BaseResponse(success=True).to_dict())
@@ -126,16 +123,14 @@ async def delete_group(request: web.Request) -> web.Response:
 @routes.get("/api/file/schedule/group/{taskListId}")
 async def get_group(request: web.Request) -> web.Response:
     try:
-        group_id = request.match_info.get("taskListId")
-        if not group_id:
+        if not (group_id := request.match_info.get("taskListId")):
             raise SupernoteError("Missing taskListId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        group = await schedule_service.get_group(user_id, group_id)
-        if not group:
+        if not (group := await schedule_service.get_group(user_id, group_id)):
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(
@@ -264,10 +259,11 @@ async def update_task(request: web.Request) -> web.Response:
         user_id = await request.app["user_service"].get_user_id(user)
 
         updates = _extract_task_updates(dto)
-        updated_task = await schedule_service.update_task(
-            user_id, dto.task_id, **updates
-        )
-        if not updated_task:
+        if not (
+            updated_task := await schedule_service.update_task(
+                user_id, dto.task_id, **updates
+            )
+        ):
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(
@@ -309,16 +305,14 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
 @routes.delete("/api/file/schedule/task/{taskId}")
 async def delete_task(request: web.Request) -> web.Response:
     try:
-        task_id = request.match_info.get("taskId")
-        if not task_id:
+        if not (task_id := request.match_info.get("taskId")):
             raise SupernoteError("Missing taskId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        success = await schedule_service.delete_task(user_id, task_id)
-        if not success:
+        if not await schedule_service.delete_task(user_id, task_id):
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(BaseResponse(success=True).to_dict())
@@ -331,16 +325,14 @@ async def delete_task(request: web.Request) -> web.Response:
 @routes.get("/api/file/schedule/task/{taskId}")
 async def get_task(request: web.Request) -> web.Response:
     try:
-        task_id = request.match_info.get("taskId")
-        if not task_id:
+        if not (task_id := request.match_info.get("taskId")):
             raise SupernoteError("Missing taskId", status_code=400)
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        task = await schedule_service.get_task(user_id, task_id)
-        if not task:
+        if not (task := await schedule_service.get_task(user_id, task_id)):
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(

--- a/supernote/server/routes/schedule.py
+++ b/supernote/server/routes/schedule.py
@@ -43,7 +43,7 @@ def _extract_task_updates(dto: UpdateScheduleTaskDTO) -> dict[str, Any]:
         val = getattr(dto, f.name)
         if val is not None:
             if f.name == "task_list_id":
-                updates["task_list_id"] = int(val)
+                updates["task_list_id"] = str(val)
             elif f.name == "is_reminder_on":
                 updates["is_reminder_on"] = val == BooleanEnum.YES
             else:
@@ -90,7 +90,7 @@ async def update_group(request: web.Request) -> web.Response:
         user_id = await request.app["user_service"].get_user_id(user)
 
         group = await schedule_service.update_group(
-            user_id, int(dto.task_list_id), dto.title
+            user_id, str(dto.task_list_id), dto.title
         )
         if not group:
             raise SupernoteError("Not found", status_code=404)
@@ -110,7 +110,7 @@ async def delete_group(request: web.Request) -> web.Response:
         if not group_id_str:
             raise SupernoteError("Missing taskListId", status_code=400)
 
-        group_id = int(group_id_str)
+        group_id = str(group_id_str)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -137,14 +137,14 @@ async def get_group(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        group = await schedule_service.get_group(user_id, int(group_id_str))
+        group = await schedule_service.get_group(user_id, str(group_id_str))
         if not group:
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(
             GetScheduleTaskGroupVO(
                 success=True,
-                task_list_id=str(group.task_list_id),
+                task_list_id=group.id,
                 user_id=group.user_id,
                 title=group.title,
                 create_time=group.create_time,
@@ -166,7 +166,7 @@ async def clear_group(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        await schedule_service.clear_group_tasks(user_id, int(dto.task_list_id))
+        await schedule_service.clear_group_tasks(user_id, str(dto.task_list_id))
         return web.json_response(BaseResponse(success=True).to_dict())
     except SupernoteError as err:
         return err.to_response()
@@ -185,7 +185,7 @@ async def list_groups(request: web.Request) -> web.Response:
 
         items = [
             ScheduleTaskGroupItem(
-                task_list_id=str(g.task_list_id),
+                task_list_id=g.id,
                 user_id=g.user_id,
                 title=g.title,
                 last_modified=g.create_time,
@@ -213,7 +213,7 @@ async def create_task(request: web.Request) -> web.Response:
         if not dto.title:
             raise SupernoteError("Title is required", status_code=400)
 
-        group_id = int(dto.task_list_id) if dto.task_list_id else 0
+        group_id = str(dto.task_list_id) if dto.task_list_id else "0"
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
@@ -239,11 +239,10 @@ async def create_task(request: web.Request) -> web.Response:
             sort_time=dto.sort_time,
             planer_sort_time=dto.planer_sort_time,
             all_sort_time=dto.all_sort_time,
-            task_id=int(dto.task_id) if dto.task_id else None,
+            task_id=str(dto.task_id) if dto.task_id else None,
         )
-        task_id_resp = str(task.task_id)
         return web.json_response(
-            AddScheduleTaskVO(success=True, task_id=task_id_resp).to_dict()
+            AddScheduleTaskVO(success=True, task_id=task.id).to_dict()
         )
     except SupernoteError as err:
         return err.to_response()
@@ -261,7 +260,7 @@ async def update_task(request: web.Request) -> web.Response:
         if not dto.task_id:
             raise SupernoteError("Missing taskId", status_code=400)
 
-        task_id = int(dto.task_id)
+        task_id = str(dto.task_id)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -272,9 +271,7 @@ async def update_task(request: web.Request) -> web.Response:
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(
-            UpdateScheduleTaskVO(
-                success=True, task_id=str(updated_task.task_id)
-            ).to_dict()
+            UpdateScheduleTaskVO(success=True, task_id=updated_task.id).to_dict()
         )
     except SupernoteError as err:
         return err.to_response()
@@ -296,7 +293,7 @@ async def batch_update_task_list(request: web.Request) -> web.Response:
         for item in dto.update_schedule_task_list:
             if item.task_id:
                 item_updates = _extract_task_updates(item)
-                item_updates["task_id"] = int(item.task_id)
+                item_updates["task_id"] = str(item.task_id)
                 updates_list.append(item_updates)
 
         await schedule_service.batch_update_tasks(user_id, updates_list)
@@ -316,7 +313,7 @@ async def delete_task(request: web.Request) -> web.Response:
         if not task_id_str:
             raise SupernoteError("Missing taskId", status_code=400)
 
-        task_id = int(task_id_str)
+        task_id = str(task_id_str)
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
@@ -343,15 +340,15 @@ async def get_task(request: web.Request) -> web.Response:
         schedule_service: ScheduleService = request.app["schedule_service"]
         user_id = await request.app["user_service"].get_user_id(user)
 
-        task = await schedule_service.get_task(user_id, int(task_id_str))
+        task = await schedule_service.get_task(user_id, str(task_id_str))
         if not task:
             raise SupernoteError("Not found", status_code=404)
 
         return web.json_response(
             ScheduleTaskVO(
                 success=True,
-                task_id=str(task.task_id),
-                task_list_id=str(task.task_list_id),
+                task_id=task.id,
+                task_list_id=task.group_id,
                 title=task.title,
                 detail=task.detail,
                 status=task.status,
@@ -387,7 +384,7 @@ async def list_tasks(request: web.Request) -> web.Response:
         except Exception:
             data = {}
         dto = ScheduleTaskDTO.from_dict(data)
-        group_id = int(dto.task_list_id) if dto.task_list_id else None
+        group_id = str(dto.task_list_id) if dto.task_list_id else None
 
         user = request["user"]
         schedule_service: ScheduleService = request.app["schedule_service"]
@@ -404,8 +401,8 @@ async def list_tasks(request: web.Request) -> web.Response:
 
         tasks_vos = [
             ScheduleTaskInfo(
-                task_id=str(t.task_id),
-                task_list_id=str(t.task_list_id),
+                task_id=t.id,
+                task_list_id=t.group_id,
                 title=t.title,
                 detail=t.detail,
                 status=t.status,
@@ -472,11 +469,7 @@ async def get_schedule_feed_ics(request: web.Request) -> web.Response:
     user_id = await user_service.get_user_id(user_email)
 
     task_list_id_str = request.query.get("taskListId")
-    task_list_id = (
-        int(task_list_id_str)
-        if task_list_id_str and task_list_id_str.isdigit()
-        else None
-    )
+    task_list_id = str(task_list_id_str) if task_list_id_str else None
 
     schedule_service: ScheduleService = request.app["schedule_service"]
     ical_export_service = ICalExportService(

--- a/supernote/server/services/ical_export.py
+++ b/supernote/server/services/ical_export.py
@@ -135,7 +135,7 @@ class ICalExportService:
     async def export_calendar(
         self,
         user_id: int,
-        task_list_id: int | None = None,
+        task_list_id: str | None = None,
     ) -> str:
         """Export user tasks to an RFC 5545 compliant iCalendar (.ics) string."""
         # 1. Fetch group titles map

--- a/supernote/server/services/ical_export.py
+++ b/supernote/server/services/ical_export.py
@@ -29,7 +29,7 @@ def map_importance_to_priority(importance: str | None) -> int | None:
     """Map Supernote task importance to RFC 5545 priority (1-9)."""
     if not importance:
         return None
-    imp_lower = str(importance).lower()
+    imp_lower = importance.lower()
     if imp_lower in ("high", "1"):
         return 1
     if imp_lower in ("normal", "medium", "5"):
@@ -66,7 +66,11 @@ def task_to_vtodo(
     group_title: str | None = None,
 ) -> Todo:
     """Convert a Supernote schedule task object to an ical.todo.Todo object."""
-    task_id = str(task.task_id) if task.task_id is not None else "unknown"
+    task_id = (
+        getattr(task, "id", None)
+        or getattr(task, "task_id", None)
+        or "unknown"
+    )
     uid = f"supernote-task-{task_id}@supernote"
 
     # Status mapping
@@ -138,9 +142,12 @@ class ICalExportService:
         task_list_id: str | None = None,
     ) -> str:
         """Export user tasks to an RFC 5545 compliant iCalendar (.ics) string."""
-        # 1. Fetch group titles map
+        # 1. Fetch group titles map (indexed by both DO.id and DO.task_list_id)
         groups = await self.schedule_service.list_groups(user_id)
-        groups_map = {g.task_list_id: g.title for g in groups}
+        groups_map: dict[str | int, str] = {}
+        for g in groups:
+            groups_map[g.id] = g.title
+            groups_map[g.task_list_id] = g.title
 
         # 2. Fetch tasks for user
         tasks = await self.schedule_service.list_tasks(user_id, group_id=task_list_id)
@@ -149,7 +156,10 @@ class ICalExportService:
         calendar = Calendar()
         for task in tasks:
             group_title = (
-                groups_map.get(task.task_list_id) if task.task_list_id else None
+                groups_map.get(task.group_id)
+                or groups_map.get(task.task_list_id)
+                if task.task_list_id
+                else None
             )
             todo = task_to_vtodo(task, group_title=group_title)
             calendar.todos.append(todo)

--- a/supernote/server/services/ical_export.py
+++ b/supernote/server/services/ical_export.py
@@ -66,11 +66,7 @@ def task_to_vtodo(
     group_title: str | None = None,
 ) -> Todo:
     """Convert a Supernote schedule task object to an ical.todo.Todo object."""
-    task_id = (
-        getattr(task, "id", None)
-        or getattr(task, "task_id", None)
-        or "unknown"
-    )
+    task_id = getattr(task, "id", None) or getattr(task, "task_id", None) or "unknown"
     uid = f"supernote-task-{task_id}@supernote"
 
     # Status mapping
@@ -156,8 +152,7 @@ class ICalExportService:
         calendar = Calendar()
         for task in tasks:
             group_title = (
-                groups_map.get(task.group_id)
-                or groups_map.get(task.task_list_id)
+                groups_map.get(task.group_id) or groups_map.get(task.task_list_id)
                 if task.task_list_id
                 else None
             )

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -85,7 +85,7 @@ class ScheduleService:
             stmt = select(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
                 or_(
-                    ScheduleTaskGroupDO.client_task_list_id == str(group_id),
+                    ScheduleTaskGroupDO.client_task_list_id == group_id,
                     ScheduleTaskGroupDO.task_list_id == group_id,
                 ),
             )
@@ -202,16 +202,15 @@ class ScheduleService:
             raise ValueError("Detail is too long")
         async with self.session_manager.session() as session:
             group = await self.get_group(user_id, group_id)
-            int_group_id = (
-                group.task_list_id
-                if group
-                else (int(group_id) if str(group_id).isdigit() else 0)
-            )
-            client_group_id = (
-                str(group_id)
-                if int_group_id == 0
-                else (group.client_task_list_id if group else None)
-            )
+            if group:
+                int_group_id = group.task_list_id
+                client_group_id = group.client_task_list_id
+            elif group_id.isdigit():
+                int_group_id = int(group_id)
+                client_group_id = None
+            else:
+                int_group_id = 0
+                client_group_id = group_id
 
             kwargs: dict[str, Any] = {
                 "user_id": user_id,
@@ -235,10 +234,10 @@ class ScheduleService:
                 "all_sort_time": all_sort_time,
             }
             if task_id is not None:
-                if str(task_id).isdigit():
+                if task_id.isdigit():
                     kwargs["task_id"] = int(task_id)
                 else:
-                    kwargs["client_task_id"] = str(task_id)
+                    kwargs["client_task_id"] = task_id
 
             task = ScheduleTaskDO(**kwargs)
             session.add(task)
@@ -253,7 +252,7 @@ class ScheduleService:
             stmt = select(ScheduleTaskDO).where(
                 ScheduleTaskDO.user_id == user_id,
                 or_(
-                    ScheduleTaskDO.client_task_id == str(task_id),
+                    ScheduleTaskDO.client_task_id == task_id,
                     ScheduleTaskDO.task_id == task_id,
                 ),
             )
@@ -272,7 +271,7 @@ class ScheduleService:
             if group_id is not None:
                 query = query.where(
                     or_(
-                        ScheduleTaskDO.client_task_list_id == str(group_id),
+                        ScheduleTaskDO.client_task_list_id == group_id,
                         ScheduleTaskDO.task_list_id == group_id,
                     )
                 )

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -2,7 +2,7 @@ import logging
 import time
 from typing import Any, cast
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, or_, select, update
 from sqlalchemy.engine import CursorResult
 
 from supernote.server.db.models.schedule import ScheduleTaskDO, ScheduleTaskGroupDO
@@ -43,24 +43,26 @@ TASK_ALLOWED_UPDATE_FIELDS: set[str] = TASK_BASE_FIELDS | TASK_SORT_FIELDS | {"l
 class ScheduleService:
     """Schedule service."""
 
-    def __init__(self, session_manager: DatabaseSessionManager):
+    def __init__(self, session_manager: DatabaseSessionManager) -> None:
         """Initialize the schedule service."""
         self.session_manager = session_manager
 
     # Task Group Operations
 
-    async def create_group(self, user_id: int, title: str) -> ScheduleTaskGroupDO:
+    async def create_group(
+        self, user_id: int, title: str, client_task_list_id: str | None = None
+    ) -> ScheduleTaskGroupDO:
         """Create a new task group."""
         if len(title) > MAX_TITLE_LENGTH:
             raise ValueError("Title is too long")
         async with self.session_manager.session() as session:
-            group = ScheduleTaskGroupDO(user_id=user_id, title=title)
+            kwargs: dict[str, Any] = {"user_id": user_id, "title": title}
+            if client_task_list_id is not None:
+                kwargs["client_task_list_id"] = client_task_list_id
+            group = ScheduleTaskGroupDO(**kwargs)
             session.add(group)
-            # Flush to generate ID
             await session.flush()
-            # Commit to persist
             await session.commit()
-            # Refresh to get defaults if any
             await session.refresh(group)
             return group
 
@@ -76,29 +78,36 @@ class ScheduleService:
             return list(result.scalars().all())
 
     async def get_group(
-        self, user_id: int, group_id: int
+        self, user_id: int, group_id: str
     ) -> ScheduleTaskGroupDO | None:
         """Get a task group by ID."""
         async with self.session_manager.session() as session:
             stmt = select(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
-                ScheduleTaskGroupDO.task_list_id == group_id,
+                or_(
+                    ScheduleTaskGroupDO.client_task_list_id == str(group_id),
+                    ScheduleTaskGroupDO.task_list_id == group_id,
+                ),
             )
             result = await session.execute(stmt)
             return result.scalar_one_or_none()
 
     async def update_group(
-        self, user_id: int, group_id: int, title: str
+        self, user_id: int, group_id: str, title: str
     ) -> ScheduleTaskGroupDO | None:
         """Update a task group title."""
         if len(title) > MAX_TITLE_LENGTH:
             raise ValueError("Title is too long")
         async with self.session_manager.session() as session:
+            group = await self.get_group(user_id, group_id)
+            if not group:
+                return None
+
             stmt = (
                 update(ScheduleTaskGroupDO)
                 .where(
                     ScheduleTaskGroupDO.user_id == user_id,
-                    ScheduleTaskGroupDO.task_list_id == group_id,
+                    ScheduleTaskGroupDO.task_list_id == group.task_list_id,
                 )
                 .values(title=title)
                 .execution_options(synchronize_session="fetch")
@@ -106,40 +115,57 @@ class ScheduleService:
             await session.execute(stmt)
             await session.commit()
 
-            # Retrieve updated
             stmt_get = select(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
-                ScheduleTaskGroupDO.task_list_id == group_id,
+                ScheduleTaskGroupDO.task_list_id == group.task_list_id,
             )
             result = await session.execute(stmt_get)
             return result.scalar_one_or_none()
 
-    async def delete_group(self, user_id: int, group_id: int) -> bool:
+    async def delete_group(self, user_id: int, group_id: str) -> bool:
         """Delete a task group and cascade delete all contained tasks."""
         async with self.session_manager.session() as session:
-            # First cascade delete all tasks in the group
+            group = await self.get_group(user_id, group_id)
+            if not group:
+                return False
+
+            # Cascade delete all tasks in group
+            task_conds = [ScheduleTaskDO.task_list_id == group.task_list_id]
+            if group.client_task_list_id:
+                task_conds.append(
+                    ScheduleTaskDO.client_task_list_id == group.client_task_list_id
+                )
+
             stmt_tasks = delete(ScheduleTaskDO).where(
-                ScheduleTaskDO.user_id == user_id,
-                ScheduleTaskDO.task_list_id == group_id,
+                ScheduleTaskDO.user_id == user_id, or_(*task_conds)
             )
             await session.execute(stmt_tasks)
 
-            # Then delete the group itself
+            # Delete group
             stmt_group = delete(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
-                ScheduleTaskGroupDO.task_list_id == group_id,
+                ScheduleTaskGroupDO.task_list_id == group.task_list_id,
             )
             result = await session.execute(stmt_group)
             await session.commit()
 
             return bool(getattr(result, "rowcount", 0) > 0)
 
-    async def clear_group_tasks(self, user_id: int, group_id: int) -> bool:
+    async def clear_group_tasks(self, user_id: int, group_id: str) -> bool:
         """Clear all tasks from a task group without deleting the group."""
         async with self.session_manager.session() as session:
+            group = await self.get_group(user_id, group_id)
+            if not group:
+                return False
+
+            task_conds = [ScheduleTaskDO.task_list_id == group.task_list_id]
+            if group.client_task_list_id:
+                task_conds.append(
+                    ScheduleTaskDO.client_task_list_id == group.client_task_list_id
+                )
+
             stmt = delete(ScheduleTaskDO).where(
-                ScheduleTaskDO.user_id == user_id,
-                ScheduleTaskDO.task_list_id == group_id,
+                ScheduleTaskDO.user_id == user_id, or_(*task_conds)
             )
             result = await session.execute(stmt)
             await session.commit()
@@ -150,7 +176,7 @@ class ScheduleService:
     async def create_task(
         self,
         user_id: int,
-        group_id: int,
+        group_id: str,
         title: str,
         detail: str = "",
         status: str = "needsAction",
@@ -167,7 +193,7 @@ class ScheduleService:
         sort_time: int | None = None,
         planer_sort_time: int | None = None,
         all_sort_time: int | None = None,
-        task_id: int | None = None,
+        task_id: str | None = None,
     ) -> ScheduleTaskDO:
         """Create a new task."""
         if len(title) > MAX_TITLE_LENGTH:
@@ -175,9 +201,22 @@ class ScheduleService:
         if len(detail) > MAX_DETAIL_LENGTH:
             raise ValueError("Detail is too long")
         async with self.session_manager.session() as session:
+            group = await self.get_group(user_id, group_id)
+            int_group_id = (
+                group.task_list_id
+                if group
+                else (int(group_id) if str(group_id).isdigit() else 0)
+            )
+            client_group_id = (
+                str(group_id)
+                if int_group_id == 0
+                else (group.client_task_list_id if group else None)
+            )
+
             kwargs: dict[str, Any] = {
                 "user_id": user_id,
-                "task_list_id": group_id,
+                "task_list_id": int_group_id,
+                "client_task_list_id": client_group_id,
                 "title": title,
                 "detail": detail,
                 "status": status,
@@ -196,7 +235,11 @@ class ScheduleService:
                 "all_sort_time": all_sort_time,
             }
             if task_id is not None:
-                kwargs["task_id"] = task_id
+                if str(task_id).isdigit():
+                    kwargs["task_id"] = int(task_id)
+                else:
+                    kwargs["client_task_id"] = str(task_id)
+
             task = ScheduleTaskDO(**kwargs)
             session.add(task)
             await session.flush()
@@ -204,12 +247,15 @@ class ScheduleService:
             await session.refresh(task)
             return task
 
-    async def get_task(self, user_id: int, task_id: int) -> ScheduleTaskDO | None:
+    async def get_task(self, user_id: int, task_id: str) -> ScheduleTaskDO | None:
         """Get a task by ID."""
         async with self.session_manager.session() as session:
             stmt = select(ScheduleTaskDO).where(
                 ScheduleTaskDO.user_id == user_id,
-                ScheduleTaskDO.task_id == task_id,
+                or_(
+                    ScheduleTaskDO.client_task_id == str(task_id),
+                    ScheduleTaskDO.task_id == task_id,
+                ),
             )
             result = await session.execute(stmt)
             return result.scalar_one_or_none()
@@ -217,14 +263,20 @@ class ScheduleService:
     async def list_tasks(
         self,
         user_id: int,
-        group_id: int | None = None,
+        group_id: str | None = None,
         since: int | None = None,
     ) -> list[ScheduleTaskDO]:
         """List tasks for a user, optionally filtered by group and since timestamp."""
         async with self.session_manager.session() as session:
             query = select(ScheduleTaskDO).where(ScheduleTaskDO.user_id == user_id)
             if group_id is not None:
-                query = query.where(ScheduleTaskDO.task_list_id == group_id)
+                query = query.where(
+                    or_(
+                        ScheduleTaskDO.client_task_list_id == str(group_id),
+                        ScheduleTaskDO.task_list_id == group_id,
+                    )
+                )
+
             if since is not None:
                 query = query.where(ScheduleTaskDO.update_time > since)
 
@@ -233,17 +285,22 @@ class ScheduleService:
             return list(result.scalars().all())
 
     async def update_task(
-        self, user_id: int, task_id: int, **kwargs: Any
+        self, user_id: int, task_id: str, **kwargs: Any
     ) -> ScheduleTaskDO | None:
         """Update a task."""
         updates = {k: v for k, v in kwargs.items() if k in TASK_ALLOWED_UPDATE_FIELDS}
         updates["update_time"] = int(time.time() * 1000)
 
         async with self.session_manager.session() as session:
+            task = await self.get_task(user_id, task_id)
+            if not task:
+                return None
+
             stmt = (
                 update(ScheduleTaskDO)
                 .where(
-                    ScheduleTaskDO.user_id == user_id, ScheduleTaskDO.task_id == task_id
+                    ScheduleTaskDO.user_id == user_id,
+                    ScheduleTaskDO.task_id == task.task_id,
                 )
                 .values(**updates)
                 .execution_options(synchronize_session="fetch")
@@ -251,9 +308,9 @@ class ScheduleService:
             await session.execute(stmt)
             await session.commit()
 
-            # Retrieve updated
             stmt_get = select(ScheduleTaskDO).where(
-                ScheduleTaskDO.user_id == user_id, ScheduleTaskDO.task_id == task_id
+                ScheduleTaskDO.user_id == user_id,
+                ScheduleTaskDO.task_id == task.task_id,
             )
             result = await session.execute(stmt_get)
             return result.scalar_one_or_none()
@@ -274,6 +331,10 @@ class ScheduleService:
                 if detail is not None and len(detail) > MAX_DETAIL_LENGTH:
                     raise ValueError("Detail is too long")
 
+                task = await self.get_task(user_id, str(task_id))
+                if not task:
+                    raise ValueError(f"Task {task_id} not found")
+
                 updates = {
                     k: v
                     for k, v in item.items()
@@ -286,21 +347,24 @@ class ScheduleService:
                     update(ScheduleTaskDO)
                     .where(
                         ScheduleTaskDO.user_id == user_id,
-                        ScheduleTaskDO.task_id == task_id,
+                        ScheduleTaskDO.task_id == task.task_id,
                     )
                     .values(**updates)
                 )
-                res = await session.execute(stmt)
-                if getattr(res, "rowcount", 0) == 0:
-                    raise ValueError(f"Task {task_id} not found")
+                await session.execute(stmt)
             await session.commit()
             return True
 
-    async def delete_task(self, user_id: int, task_id: int) -> bool:
+    async def delete_task(self, user_id: int, task_id: str) -> bool:
         """Delete a task."""
         async with self.session_manager.session() as session:
+            task = await self.get_task(user_id, task_id)
+            if not task:
+                return False
+
             stmt = delete(ScheduleTaskDO).where(
-                ScheduleTaskDO.user_id == user_id, ScheduleTaskDO.task_id == task_id
+                ScheduleTaskDO.user_id == user_id,
+                ScheduleTaskDO.task_id == task.task_id,
             )
             result = cast(CursorResult[Any], await session.execute(stmt))
             await session.commit()

--- a/supernote/server/services/schedule.py
+++ b/supernote/server/services/schedule.py
@@ -61,6 +61,7 @@ class ScheduleService:
                 kwargs["client_task_list_id"] = client_task_list_id
             group = ScheduleTaskGroupDO(**kwargs)
             session.add(group)
+            # Flush to generate ID
             await session.flush()
             await session.commit()
             await session.refresh(group)
@@ -99,8 +100,7 @@ class ScheduleService:
         if len(title) > MAX_TITLE_LENGTH:
             raise ValueError("Title is too long")
         async with self.session_manager.session() as session:
-            group = await self.get_group(user_id, group_id)
-            if not group:
+            if not (group := await self.get_group(user_id, group_id)):
                 return None
 
             stmt = (
@@ -115,6 +115,7 @@ class ScheduleService:
             await session.execute(stmt)
             await session.commit()
 
+            # Retrieve updated
             stmt_get = select(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
                 ScheduleTaskGroupDO.task_list_id == group.task_list_id,
@@ -125,11 +126,10 @@ class ScheduleService:
     async def delete_group(self, user_id: int, group_id: str) -> bool:
         """Delete a task group and cascade delete all contained tasks."""
         async with self.session_manager.session() as session:
-            group = await self.get_group(user_id, group_id)
-            if not group:
+            if not (group := await self.get_group(user_id, group_id)):
                 return False
 
-            # Cascade delete all tasks in group
+            # First cascade delete all tasks in the group
             task_conds = [ScheduleTaskDO.task_list_id == group.task_list_id]
             if group.client_task_list_id:
                 task_conds.append(
@@ -141,7 +141,7 @@ class ScheduleService:
             )
             await session.execute(stmt_tasks)
 
-            # Delete group
+            # Then delete the group itself
             stmt_group = delete(ScheduleTaskGroupDO).where(
                 ScheduleTaskGroupDO.user_id == user_id,
                 ScheduleTaskGroupDO.task_list_id == group.task_list_id,
@@ -154,10 +154,10 @@ class ScheduleService:
     async def clear_group_tasks(self, user_id: int, group_id: str) -> bool:
         """Clear all tasks from a task group without deleting the group."""
         async with self.session_manager.session() as session:
-            group = await self.get_group(user_id, group_id)
-            if not group:
+            if not (group := await self.get_group(user_id, group_id)):
                 return False
 
+            # Clear all tasks from the group without deleting the group
             task_conds = [ScheduleTaskDO.task_list_id == group.task_list_id]
             if group.client_task_list_id:
                 task_conds.append(
@@ -201,8 +201,7 @@ class ScheduleService:
         if len(detail) > MAX_DETAIL_LENGTH:
             raise ValueError("Detail is too long")
         async with self.session_manager.session() as session:
-            group = await self.get_group(user_id, group_id)
-            if group:
+            if group := await self.get_group(user_id, group_id):
                 int_group_id = group.task_list_id
                 client_group_id = group.client_task_list_id
             elif group_id.isdigit():
@@ -241,6 +240,7 @@ class ScheduleService:
 
             task = ScheduleTaskDO(**kwargs)
             session.add(task)
+            # Flush to generate ID
             await session.flush()
             await session.commit()
             await session.refresh(task)
@@ -291,8 +291,7 @@ class ScheduleService:
         updates["update_time"] = int(time.time() * 1000)
 
         async with self.session_manager.session() as session:
-            task = await self.get_task(user_id, task_id)
-            if not task:
+            if not (task := await self.get_task(user_id, task_id)):
                 return None
 
             stmt = (
@@ -307,6 +306,7 @@ class ScheduleService:
             await session.execute(stmt)
             await session.commit()
 
+            # Retrieve updated
             stmt_get = select(ScheduleTaskDO).where(
                 ScheduleTaskDO.user_id == user_id,
                 ScheduleTaskDO.task_id == task.task_id,
@@ -320,18 +320,18 @@ class ScheduleService:
         """Batch update tasks atomically in a single transaction."""
         async with self.session_manager.session() as session:
             for item in updates_list:
-                task_id = item.get("task_id")
-                if not task_id:
+                if not (task_id := item.get("task_id")):
                     continue
-                title = item.get("title")
-                if title is not None and len(title) > MAX_TITLE_LENGTH:
+                if (title := item.get("title")) is not None and len(
+                    title
+                ) > MAX_TITLE_LENGTH:
                     raise ValueError("Title is too long")
-                detail = item.get("detail")
-                if detail is not None and len(detail) > MAX_DETAIL_LENGTH:
+                if (detail := item.get("detail")) is not None and len(
+                    detail
+                ) > MAX_DETAIL_LENGTH:
                     raise ValueError("Detail is too long")
 
-                task = await self.get_task(user_id, str(task_id))
-                if not task:
+                if not (task := await self.get_task(user_id, str(task_id))):
                     raise ValueError(f"Task {task_id} not found")
 
                 updates = {
@@ -357,8 +357,7 @@ class ScheduleService:
     async def delete_task(self, user_id: int, task_id: str) -> bool:
         """Delete a task."""
         async with self.session_manager.session() as session:
-            task = await self.get_task(user_id, task_id)
-            if not task:
+            if not (task := await self.get_task(user_id, task_id)):
                 return False
 
             stmt = delete(ScheduleTaskDO).where(

--- a/tests/server/db/test_migrations.py
+++ b/tests/server/db/test_migrations.py
@@ -75,7 +75,7 @@ def test_migration_upgrades_successfully(migrated_db: str) -> None:
         # Check if the 'alembic_version' table exists and has the head revision
         result = conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
-        assert version == "b8e9c0d1e2f3"
+        assert version == "d1e2f3a4b5c6"
 
         # Check if a known table exists (e.g. users)
         result = conn.execute(text("SELECT count(*) FROM users"))

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -39,12 +39,12 @@ async def test_schedule_flow(authenticated_client: Client) -> None:
     group_vo = await schedule.create_group("My Projects")
     assert isinstance(group_vo, AddScheduleTaskGroupVO)
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     # List Groups
     groups = [g async for g in schedule.list_groups()]
     assert len(groups) == 1
-    my_group = next((g for g in groups if str(g.task_list_id) == str(group_id)), None)
+    my_group = next((g for g in groups if g.task_list_id == group_id), None)
     assert my_group is not None
     assert my_group.title == "My Projects"
     assert isinstance(my_group, ScheduleTaskGroupItem)
@@ -59,14 +59,14 @@ async def test_schedule_flow(authenticated_client: Client) -> None:
     )
     assert isinstance(task_vo, AddScheduleTaskVO)
     assert task_vo.task_id is not None
-    task_id = int(task_vo.task_id)
+    task_id = task_vo.task_id
 
     # List Tasks
     tasks = [t async for t in schedule.list_tasks(group_id)]
     assert len(tasks) == 1
     task = tasks[0]
-    assert str(task.task_id) == str(task_id)
-    assert str(task.task_list_id) == str(group_id)
+    assert task.task_id == task_id
+    assert task.task_list_id == group_id
     assert task.title == "Finish Refactor"
     assert task.is_reminder_on == BooleanEnum.NO
 
@@ -75,7 +75,7 @@ async def test_schedule_flow(authenticated_client: Client) -> None:
         task_id, title="Finish Refactor", status="completed", is_reminder_on=True
     )
     assert isinstance(update_vo, UpdateScheduleTaskVO)
-    assert str(update_vo.task_id) == str(task_id)
+    assert update_vo.task_id == task_id
 
     # Verify update
     tasks_after = [t async for t in schedule.list_tasks(group_id)]
@@ -98,13 +98,13 @@ async def test_update_task_fields(authenticated_client: Client) -> None:
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("Update Test Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     task_vo = await schedule.create_task(
         group_id, "Original Title", detail="Original Detail", due_time=1000
     )
     assert task_vo.task_id is not None
-    task_id = int(task_vo.task_id)
+    task_id = task_vo.task_id
 
     await schedule.update_task(task_id, title="Updated Title")
     tasks = [t async for t in schedule.list_tasks(group_id)]
@@ -144,7 +144,7 @@ async def test_update_task_partial_payload(authenticated_client: Client) -> None
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("Partial Update Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     task_vo = await schedule.create_task(group_id, "Original Title")
     assert task_vo.task_id is not None
@@ -171,7 +171,7 @@ async def test_task_links_and_sort_fields_persistence(
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("Links Test Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     link_dto = ScheduleTaskLinkDTO(
         app_name="Note",
@@ -187,7 +187,7 @@ async def test_task_links_and_sort_fields_persistence(
     )
     assert create_vo.success is True
     assert create_vo.task_id is not None
-    task_id = int(create_vo.task_id)
+    task_id = create_vo.task_id
 
     task_detail = await schedule.get_task(task_id)
     assert task_detail.success is True
@@ -204,7 +204,7 @@ async def test_task_notebook_links_encoding_and_decoding(
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("Notebook Links Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     # Construct explicit Supernote notebook link using ScheduleTaskLinkDTO
     link_dto = ScheduleTaskLinkDTO(
@@ -226,7 +226,7 @@ async def test_task_notebook_links_encoding_and_decoding(
     )
     assert create_vo.success is True
     assert create_vo.task_id is not None
-    task_id = int(create_vo.task_id)
+    task_id = create_vo.task_id
 
     # Verify GET task returns exact links string and decodes using ScheduleTaskLinkDTO.from_b64
     task_detail = await schedule.get_task(task_id)
@@ -253,13 +253,13 @@ async def test_schedule_group_and_task_routes(
     # Create Group
     group_vo = await schedule.create_group("Group Alpha")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     # Get Group Details
     group_detail = await schedule.get_group(group_id)
     assert group_detail.success is True
     assert group_detail.title == "Group Alpha"
-    assert str(group_detail.task_list_id) == str(group_id)
+    assert group_detail.task_list_id == group_id
 
     # Update Group Title
     up_res = await schedule.update_group(group_id, "Group Alpha Updated")
@@ -270,7 +270,7 @@ async def test_schedule_group_and_task_routes(
     # Create Task & Get Task
     task_vo = await schedule.create_task(group_id, "Task Beta", detail="Beta detail")
     assert task_vo.task_id is not None
-    task_id = int(task_vo.task_id)
+    task_id = task_vo.task_id
 
     task_detail = await schedule.get_task(task_id)
     assert task_detail.success is True
@@ -316,28 +316,28 @@ async def test_batch_update_task_list_transactional_rollback(
 
     group_vo = await schedule.create_group("Batch Test Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     task1_vo = await schedule.create_task(group_id, "Task 1", detail="Detail 1")
     task2_vo = await schedule.create_task(group_id, "Task 2", detail="Detail 2")
     assert task1_vo.task_id is not None
     assert task2_vo.task_id is not None
 
-    task1_id = int(task1_vo.task_id)
-    task2_id = int(task2_vo.task_id)
+    task1_id = task1_vo.task_id
+    task2_id = task2_vo.task_id
 
     # Batch update where Task 1 is valid, but Task 2 exceeds MAX_TITLE_LENGTH
     invalid_title = "A" * 300
     batch_payload = {
-        "taskListId": str(group_id),
+        "taskListId": group_id,
         "updateScheduleTaskList": [
             {
-                "taskId": str(task1_id),
+                "taskId": task1_id,
                 "title": "Task 1 Updated",
                 "lastModified": 1000,
             },
             {
-                "taskId": str(task2_id),
+                "taskId": task2_id,
                 "title": invalid_title,
                 "lastModified": 1000,
             },
@@ -368,8 +368,8 @@ async def test_list_tasks_filtering_by_group_id(
     group_b_vo = await schedule.create_group("Group B")
     assert group_a_vo.task_list_id is not None
     assert group_b_vo.task_list_id is not None
-    group_a_id = int(group_a_vo.task_list_id)
-    group_b_id = int(group_b_vo.task_list_id)
+    group_a_id = group_a_vo.task_list_id
+    group_b_id = group_b_vo.task_list_id
 
     task_a_vo = await schedule.create_task(group_a_id, "Task in Group A")
     task_b_vo = await schedule.create_task(group_b_id, "Task in Group B")
@@ -404,7 +404,7 @@ async def test_delete_group_cascades_contained_tasks(
 
     group_vo = await schedule.create_group("Cascade Route Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     task1_vo = await schedule.create_task(group_id, "Subtask 1")
     task2_vo = await schedule.create_task(group_id, "Subtask 2")
@@ -426,7 +426,7 @@ async def test_batch_update_task_list_sort_fields(
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("Sort Batch Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     task1_vo = await schedule.create_task(group_id, "Task 101")
     task2_vo = await schedule.create_task(group_id, "Task 102")
@@ -485,7 +485,7 @@ async def test_create_task_with_client_generated_id_and_server_fallback(
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("ID Test Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     # Client-provided taskId (offline Supernote device sync)
     client_custom_id = "9876543210"
@@ -498,9 +498,9 @@ async def test_create_task_with_client_generated_id_and_server_fallback(
     assert create_vo.task_id == client_custom_id
 
     # Verify task is stored under the exact client-generated taskId in DB
-    task_vo = await schedule.get_task(int(client_custom_id))
+    task_vo = await schedule.get_task(client_custom_id)
     assert task_vo.success is True
-    assert str(task_vo.task_id) == client_custom_id
+    assert task_vo.task_id == client_custom_id
     assert task_vo.title == "Offline Created Task"
 
     # Server-generated taskId fallback (when taskId omitted)
@@ -510,7 +510,7 @@ async def test_create_task_with_client_generated_id_and_server_fallback(
     assert server_task_id is not None
     assert server_task_id != client_custom_id
 
-    server_task = await schedule.get_task(int(server_task_id))
+    server_task = await schedule.get_task(server_task_id)
     assert server_task.success is True
     assert server_task.title == "Web UI Created Task"
 
@@ -522,7 +522,7 @@ async def test_schedule_delta_sync_flow(authenticated_client: Client) -> None:
     schedule = ScheduleClient(authenticated_client)
     group_vo = await schedule.create_group("Delta Sync Group")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = group_vo.task_list_id
 
     # Create initial tasks
     t1_vo = await schedule.create_task(group_id, "Task 1 Initial")
@@ -542,7 +542,8 @@ async def test_schedule_delta_sync_flow(authenticated_client: Client) -> None:
     await asyncio.sleep(0.02)
 
     # Update 1 task, add 1 task
-    await schedule.update_task(int(t1_vo.task_id), title="Task 1 Updated")
+    assert t1_vo.task_id is not None
+    await schedule.update_task(t1_vo.task_id, title="Task 1 Updated")
     t3_vo = await schedule.create_task(group_id, "Task 3 New")
     assert t3_vo.task_id is not None
 

--- a/tests/server/routes/test_schedule.py
+++ b/tests/server/routes/test_schedule.py
@@ -609,7 +609,7 @@ async def test_ical_feed_content_and_filtering(
     # Populate data via ScheduleClient
     group_vo = await schedule.create_group("Sprint Tasks")
     assert group_vo.task_list_id is not None
-    group_id = int(group_vo.task_list_id)
+    group_id = str(group_vo.task_list_id)
 
     task1 = await schedule.create_task(
         group_id,
@@ -634,3 +634,37 @@ async def test_ical_feed_content_and_filtering(
 
     # Cleanup
     await schedule.delete_group(group_id)
+
+
+async def test_schedule_string_uuid_support(authenticated_client: Client) -> None:
+    """Verify schedule routes handle string UUIDs sent by Partner App and Android clients."""
+    schedule = ScheduleClient(authenticated_client)
+
+    string_group_id = "dcf35927c2c7279e3d204f592af6e9ed"
+    string_task_id = "a1b2c3d4e5f678901234567890abcdef"
+
+    # Create task with string UUIDs
+    resp = await schedule.create_task(
+        group_id=string_group_id,
+        title="Partner App Sync Task",
+        task_id=string_task_id,
+    )
+    assert resp.success is True
+    assert resp.task_id == string_task_id
+
+    # Retrieve all tasks and verify string UUID is preserved verbatim
+    all_tasks_vo = await schedule.get_tasks_all(group_id=string_group_id)
+    assert all_tasks_vo.success is True
+    matching_task = next(
+        (t for t in all_tasks_vo.schedule_task if t.task_id == string_task_id), None
+    )
+    assert matching_task is not None
+    assert matching_task.task_list_id == string_group_id
+
+    # Get single task
+    task_vo = await schedule.get_task(string_task_id)
+    assert task_vo.success is True
+    assert task_vo.task_id == string_task_id
+
+    # Delete task
+    await schedule.delete_task(string_task_id)

--- a/tests/server/services/test_ical_export.py
+++ b/tests/server/services/test_ical_export.py
@@ -65,9 +65,7 @@ async def test_export_calendar_tasks_roundtrip(
         detail="Run schema migrations first",
         status="completed",
     )
-    await schedule_service.update_task(
-        user_id, task2.id, completed_time=1722646800000
-    )
+    await schedule_service.update_task(user_id, task2.id, completed_time=1722646800000)
 
     # Export calendar for user
     ics_text = await ical_export_service.export_calendar(user_id)

--- a/tests/server/services/test_ical_export.py
+++ b/tests/server/services/test_ical_export.py
@@ -46,7 +46,7 @@ async def test_export_calendar_tasks_roundtrip(
     """Test creating tasks and verifying iCal export round-trip parsing."""
     user_id = 888
     group = await schedule_service.create_group(user_id, "Project Alpha")
-    group_id = group.task_list_id
+    group_id = group.id
 
     # Create test tasks
     task1 = await schedule_service.create_task(
@@ -66,7 +66,7 @@ async def test_export_calendar_tasks_roundtrip(
         status="completed",
     )
     await schedule_service.update_task(
-        user_id, task2.task_id, completed_time=1722646800000
+        user_id, task2.id, completed_time=1722646800000
     )
 
     # Export calendar for user
@@ -89,7 +89,7 @@ async def test_export_calendar_tasks_roundtrip(
     assert todo1.description == "Check iCal export implementation"
     assert todo1.categories == ["Project Alpha"]
     assert todo1.priority == 1
-    assert todo1.uid == f"supernote-task-{task1.task_id}@supernote"
+    assert todo1.uid == f"supernote-task-{task1.id}@supernote"
 
 
 async def test_export_calendar_task_list_filtering(
@@ -101,12 +101,12 @@ async def test_export_calendar_task_list_filtering(
     group_a = await schedule_service.create_group(user_id, "Work")
     group_b = await schedule_service.create_group(user_id, "Personal")
 
-    await schedule_service.create_task(user_id, group_a.task_list_id, "Work Task")
-    await schedule_service.create_task(user_id, group_b.task_list_id, "Personal Task")
+    await schedule_service.create_task(user_id, group_a.id, "Work Task")
+    await schedule_service.create_task(user_id, group_b.id, "Personal Task")
 
     # Export only Group A
     ics_text_a = await ical_export_service.export_calendar(
-        user_id, task_list_id=group_a.task_list_id
+        user_id, task_list_id=group_a.id
     )
     calendar_a = IcsCalendarStream.calendar_from_ics(ics_text_a)
     assert len(calendar_a.todos) == 1

--- a/tests/server/services/test_schedule.py
+++ b/tests/server/services/test_schedule.py
@@ -25,7 +25,7 @@ async def test_group_crud(schedule_service: ScheduleService) -> None:
     assert any(g.task_list_id == group.task_list_id for g in groups)
 
     # Delete
-    deleted = await schedule_service.delete_group(user_id, group.task_list_id)
+    deleted = await schedule_service.delete_group(user_id, group.id)
     assert deleted
 
     groups_after = await schedule_service.list_groups(user_id)
@@ -55,7 +55,7 @@ async def test_group_names_are_not_unique(schedule_service: ScheduleService) -> 
     assert group1.task_list_id != group2.task_list_id
 
     # Delete the first group
-    deleted = await schedule_service.delete_group(user_id, group1.task_list_id)
+    deleted = await schedule_service.delete_group(user_id, group1.id)
     assert deleted
 
     # List groups again
@@ -70,19 +70,19 @@ async def test_task_crud(schedule_service: ScheduleService) -> None:
     group = await schedule_service.create_group(user_id, "Inbox")
 
     # Create Task
-    task = await schedule_service.create_task(user_id, group.task_list_id, "Buy Milk")
+    task = await schedule_service.create_task(user_id, group.id, "Buy Milk")
     assert task.task_id is not None
     assert task.title == "Buy Milk"
     assert task.status == "needsAction"
 
     # List Tasks
-    tasks = await schedule_service.list_tasks(user_id, group.task_list_id)
+    tasks = await schedule_service.list_tasks(user_id, group.id)
     assert len(tasks) == 1
     assert tasks[0].task_id == task.task_id
 
     # Update Task
     updated = await schedule_service.update_task(
-        user_id, task.task_id, status="completed", title="Buy Milk & Bread"
+        user_id, task.id, status="completed", title="Buy Milk & Bread"
     )
     assert updated is not None
     assert updated.status == "completed"
@@ -93,7 +93,7 @@ async def test_task_crud(schedule_service: ScheduleService) -> None:
     assert tasks_v2[0].title == "Buy Milk & Bread"
 
     # Delete Task
-    deleted = await schedule_service.delete_task(user_id, task.task_id)
+    deleted = await schedule_service.delete_task(user_id, task.id)
     assert deleted
 
     tasks_v3 = await schedule_service.list_tasks(user_id)
@@ -113,7 +113,7 @@ async def test_isolation(schedule_service: ScheduleService) -> None:
     assert l1[0].task_list_id == g1.task_list_id
 
     # User 1 cannot delete User 2 group
-    deleted = await schedule_service.delete_group(user1, g2.task_list_id)
+    deleted = await schedule_service.delete_group(user1, g2.id)
     assert not deleted
 
 
@@ -124,15 +124,15 @@ async def test_delete_group_cascades_contained_tasks(
     user_id = 777
     group = await schedule_service.create_group(user_id, "Project X")
 
-    task1 = await schedule_service.create_task(user_id, group.task_list_id, "Subtask 1")
-    task2 = await schedule_service.create_task(user_id, group.task_list_id, "Subtask 2")
+    task1 = await schedule_service.create_task(user_id, group.id, "Subtask 1")
+    task2 = await schedule_service.create_task(user_id, group.id, "Subtask 2")
     assert task1.task_id is not None
     assert task2.task_id is not None
 
-    tasks_before = await schedule_service.list_tasks(user_id, group.task_list_id)
+    tasks_before = await schedule_service.list_tasks(user_id, group.id)
     assert len(tasks_before) == 2
 
-    deleted = await schedule_service.delete_group(user_id, group.task_list_id)
+    deleted = await schedule_service.delete_group(user_id, group.id)
     assert deleted is True
 
     groups_after = await schedule_service.list_groups(user_id)


### PR DESCRIPTION
## Summary
- Adds independent `client_task_id` and `client_task_list_id` string columns to schedule DB models (`ScheduleTaskDO` and `ScheduleTaskGroupDO`).
- Adds Alembic migration `d1e2f3a4b5c6_add_client_task_ids.py`.
- Encapsulates ID formatting via `.id` and `.group_id` properties on `ScheduleTaskDO` and `ScheduleTaskGroupDO`.
- Enforces strict `str` type contracts across `ScheduleService` and `ScheduleClient`.
- Adds Socket.IO protocol middleware to rewrite `EIO=3` to `EIO=4` query params for client compatibility.
- Adds regression unit test `test_schedule_string_uuid_support`.

## Test Plan
- Run `pytest tests/server/` (317 passed).