### PR TITLE
Group notebook summaries and transcripts under parent SummaryGroup (#233)

### DIFF
--- a/supernote/server/services/processor_modules/summary.py
+++ b/supernote/server/services/processor_modules/summary.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
@@ -10,7 +11,9 @@ from sqlalchemy import select
 from supernote.models.summary import (
     METADATA_SEGMENTS,
     AddSummaryDTO,
+    AddSummaryGroupDTO,
     UpdateSummaryDTO,
+    UpdateSummaryGroupDTO,
 )
 from supernote.server.config import ServerConfig
 from supernote.server.db.models.file import UserFileDO
@@ -22,7 +25,11 @@ from supernote.server.services.gemini import GeminiService
 from supernote.server.services.processor_modules import ProcessorModule
 from supernote.server.services.summary import SummaryService
 from supernote.server.utils.note_content import format_page_metadata
-from supernote.server.utils.paths import get_summary_id, get_transcript_id
+from supernote.server.utils.paths import (
+    get_summary_group_id,
+    get_summary_id,
+    get_transcript_id,
+)
 from supernote.server.utils.prompt_loader import PROMPT_LOADER, PromptId
 
 logger = logging.getLogger(__name__)
@@ -137,6 +144,9 @@ class SummaryModule(ProcessorModule):
 
             # 2. Key Generation
             file_basis = file_do.storage_key or str(file_do.id)
+            group_uuid = get_summary_group_id(file_basis)
+            group_name = Path(file_do.file_name).name
+            group_md5 = hashlib.md5(group_name.encode("utf-8")).hexdigest()
             summary_uuid = get_summary_id(file_basis)
             transcript_uuid = get_transcript_id(file_basis)
 
@@ -169,7 +179,17 @@ class SummaryModule(ProcessorModule):
 
         full_text = "\n\n".join(text_parts)
 
-        # 4. Generate Transcript Summary (Preserve existing functionality)
+        # 4. Upsert Summary Group for the notebook
+        await self._upsert_group(
+            user_email,
+            AddSummaryGroupDTO(
+                unique_identifier=group_uuid,
+                name=group_name,
+                md5_hash=group_md5,
+            ),
+        )
+
+        # 5. Generate Transcript Summary (Preserve existing functionality)
         # Store the raw aggregated text as a 'transcript' summary type first
         # This is a good baseline to have.
         await self._upsert_summary(
@@ -177,13 +197,14 @@ class SummaryModule(ProcessorModule):
             AddSummaryDTO(
                 file_id=file_id,
                 unique_identifier=transcript_uuid,
+                parent_unique_identifier=group_uuid,
                 content=full_text,
                 data_source="OCR",
                 source_path=file_do.file_name,
             ),
         )
 
-        # 5. Generate AI Summary using Gemini
+        # 6. Generate AI Summary using Gemini
         # Determine prompt based on filename/type
         custom_type = Path(file_do.file_name).stem.lower()
 
@@ -270,12 +291,36 @@ class SummaryModule(ProcessorModule):
             AddSummaryDTO(
                 file_id=file_id,
                 unique_identifier=summary_uuid,
+                parent_unique_identifier=group_uuid,
                 content=ai_summary,
                 data_source="GEMINI",
                 source_path=file_do.file_name,
                 metadata=metadata_str,
             ),
         )
+
+    async def _upsert_group(self, user_email: str, dto: AddSummaryGroupDTO) -> None:
+        """Helper to either add or update a summary group based on its unique identifier."""
+        if not dto.unique_identifier:
+            logger.error("Cannot upsert summary group without a unique identifier")
+            return
+
+        existing = await self.summary_service.get_summary_by_uuid(
+            user_email, dto.unique_identifier
+        )
+        if existing and existing.id is not None:
+            await self.summary_service.update_group(
+                user_email,
+                UpdateSummaryGroupDTO(
+                    id=existing.id,
+                    unique_identifier=dto.unique_identifier,
+                    name=dto.name,
+                    md5_hash=dto.md5_hash,
+                    description=dto.description,
+                ),
+            )
+        else:
+            await self.summary_service.add_group(user_email, dto)
 
     async def _upsert_summary(self, user_email: str, dto: AddSummaryDTO) -> None:
         """Helper to either add or update a summary based on its unique identifier."""
@@ -291,6 +336,7 @@ class SummaryModule(ProcessorModule):
                 user_email,
                 UpdateSummaryDTO(
                     id=existing.id,
+                    parent_unique_identifier=dto.parent_unique_identifier,
                     content=dto.content,
                     data_source=dto.data_source,
                     source_path=dto.source_path,

--- a/supernote/server/services/summary.py
+++ b/supernote/server/services/summary.py
@@ -183,12 +183,18 @@ class SummaryService:
             if not summary_do:
                 raise SummaryNotFound(f"Summary with ID {dto.id} not found")
 
+            if dto.parent_unique_identifier is not None:
+                summary_do.parent_unique_identifier = dto.parent_unique_identifier
             if dto.content is not None:
                 summary_do.content = dto.content
                 if dto.md5_hash is None:
                     summary_do.md5_hash = hashlib.md5(
                         dto.content.encode("utf-8")
                     ).hexdigest()
+            if dto.source_path is not None:
+                summary_do.source_path = dto.source_path
+            if dto.data_source is not None:
+                summary_do.data_source = dto.data_source
             if dto.tags is not None:
                 summary_do.tags = dto.tags
             if dto.metadata is not None:

--- a/supernote/server/utils/paths.py
+++ b/supernote/server/utils/paths.py
@@ -17,6 +17,11 @@ def get_summary_id(file_basis: str) -> str:
     return f"{file_basis}-summary"
 
 
+def get_summary_group_id(file_basis: str) -> str:
+    """Generate a unique identifier for a summary group."""
+    return f"{file_basis}-group"
+
+
 def get_transcript_id(file_basis: str) -> str:
     """Generate a unique identifier for an OCR transcript."""
     return f"{file_basis}-transcript"

--- a/tests/server/integration/services/processor_modules/test_processor_integration.py
+++ b/tests/server/integration/services/processor_modules/test_processor_integration.py
@@ -26,6 +26,7 @@ from supernote.server.services.summary import SummaryService
 from supernote.server.services.user import UserService
 from supernote.server.utils.paths import (
     get_page_png_path,
+    get_summary_group_id,
     get_summary_id,
     get_transcript_id,
 )
@@ -171,8 +172,28 @@ async def test_full_processing_pipeline_with_real_file(
             png_path = get_page_png_path(file_id, page.page_id)
             assert await blob_storage.exists(CACHE_BUCKET, png_path)
 
-        # 5. Verify Summary existence via API
+        # 5. Verify Summary and SummaryGroup existence via API
         summary_client = SummaryClient(authenticated_client)
+
+        group_uuid = get_summary_group_id(storage_key)
+        transcript_uuid = get_transcript_id(storage_key)
+        summary_uuid = get_summary_id(storage_key)
+
+        # Query groups
+        group_response = await summary_client.query_groups()
+        assert group_response.success
+        group = next(
+            (
+                g
+                for g in group_response.summary_do_list
+                if g.unique_identifier == group_uuid
+            ),
+            None,
+        )
+        assert group is not None, (
+            f"Group {group_uuid} not found in {group_response.summary_do_list}"
+        )
+        assert group.name == "real.note"
 
         # Query all summaries
         query_response = await summary_client.query_summaries()
@@ -181,9 +202,6 @@ async def test_full_processing_pipeline_with_real_file(
         assert len(summaries) >= 2  # At least transcript and AI summary
 
         # Find our specific summaries by unique identifier
-        transcript_uuid = get_transcript_id(storage_key)
-        summary_uuid = get_summary_id(storage_key)
-
         transcript = next(
             (s for s in summaries if s.unique_identifier == transcript_uuid), None
         )
@@ -197,6 +215,10 @@ async def test_full_processing_pipeline_with_real_file(
         assert ai_summary is not None, (
             f"AI Summary {summary_uuid} not found in {summaries}"
         )
+
+        # Check parent group linkage
+        assert transcript.parent_unique_identifier == group_uuid
+        assert ai_summary.parent_unique_identifier == group_uuid
 
         # Check transcript content
         assert transcript.content is not None

--- a/tests/server/services/processor_modules/test_summary.py
+++ b/tests/server/services/processor_modules/test_summary.py
@@ -4,10 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy import select
 
+from supernote.models.base import BooleanEnum
 from supernote.models.summary import (
     METADATA_SEGMENTS,
     AddSummaryDTO,
+    AddSummaryGroupDTO,
     SummaryItem,
+    UpdateSummaryGroupDTO,
 )
 from supernote.server.config import ServerConfig
 from supernote.server.db.models.file import UserFileDO
@@ -17,7 +20,11 @@ from supernote.server.db.session import DatabaseSessionManager
 from supernote.server.services.file import FileService
 from supernote.server.services.processor_modules.summary import SummaryModule
 from supernote.server.services.summary import SummaryService
-from supernote.server.utils.paths import get_summary_id, get_transcript_id
+from supernote.server.utils.paths import (
+    get_summary_group_id,
+    get_summary_id,
+    get_transcript_id,
+)
 from supernote.server.utils.prompt_loader import PromptId
 
 
@@ -27,6 +34,8 @@ def mock_summary_service() -> MagicMock:
     service.get_summary_by_uuid = AsyncMock(return_value=None)
     service.add_summary = AsyncMock()
     service.update_summary = AsyncMock()
+    service.add_group = AsyncMock()
+    service.update_group = AsyncMock()
     return service
 
 
@@ -132,22 +141,32 @@ async def test_summary_success(
         assert "Page 2 text" in kwargs["contents"]
         assert "Generate" in kwargs["contents"]
 
-    # 1. Transcript Upsert
+    # 1. Group Upsert
+    group_call = mock_summary_service.add_group.call_args_list[0]
+    assert group_call.args[0] == user_email
+    dto_group = group_call.args[1]
+    assert isinstance(dto_group, AddSummaryGroupDTO)
+    assert dto_group.unique_identifier == get_summary_group_id(storage_key)
+    assert dto_group.name == "real.note"
+
+    # 2. Transcript Upsert
     transcript_call = mock_summary_service.add_summary.call_args_list[0]
     assert transcript_call.args[0] == user_email
     dto = transcript_call.args[1]
     assert isinstance(dto, AddSummaryDTO)
     assert dto.unique_identifier == get_transcript_id(storage_key)
+    assert dto.parent_unique_identifier == get_summary_group_id(storage_key)
     assert dto.content is not None
     assert "Page 1 text" in dto.content
     assert "Page 2 text" in dto.content
     assert dto.data_source == "OCR"
 
-    # 2. AI Summary Upsert
+    # 3. AI Summary Upsert
     ai_call = mock_summary_service.add_summary.call_args_list[1]
     assert ai_call.args[0] == user_email
     dto_ai = ai_call.args[1]
     assert dto_ai.unique_identifier == get_summary_id(storage_key)
+    assert dto_ai.parent_unique_identifier == get_summary_group_id(storage_key)
     assert "## 2023-10-27" in dto_ai.content
     assert "AI Summary Output" in dto_ai.content
     assert dto_ai.data_source == "GEMINI"
@@ -157,7 +176,7 @@ async def test_summary_success(
     meta = json.loads(dto_ai.metadata)
     assert meta[METADATA_SEGMENTS][0]["page_refs"] == [1, 2]
 
-    # 3. Check Task Status
+    # 4. Check Task Status
     async with session_manager.session() as session:
         task = (
             (
@@ -225,19 +244,39 @@ async def test_summary_idempotency_update(
     )
     mock_gemini_service.generate_content.return_value = mock_response
 
-    # Mock Existing Summary
+    # Mock Existing Group & Summary
+    existing_group = SummaryItem(
+        id=10,
+        unique_identifier=get_summary_group_id(storage_key),
+        name="update.note",
+        is_summary_group=BooleanEnum.YES,
+    )
     existing_summary = SummaryItem(id=11, unique_identifier=get_summary_id(storage_key))
-    # 1st call (transcript): return None -> calls add_summary
-    # 2nd call (ai summary): return existing -> calls update_summary
-    mock_summary_service.get_summary_by_uuid.side_effect = [None, existing_summary]
+    # 1st call (group): return existing -> calls update_group
+    # 2nd call (transcript): return None -> calls add_summary
+    # 3rd call (ai summary): return existing -> calls update_summary
+    mock_summary_service.get_summary_by_uuid.side_effect = [
+        existing_group,
+        None,
+        existing_summary,
+    ]
 
     # Run module
     await summary_module.run(file_id, session_manager)
+
+    # Group should be updated
+    mock_summary_service.update_group.assert_called_once()
+    update_group_dto = mock_summary_service.update_group.call_args.args[1]
+    assert isinstance(update_group_dto, UpdateSummaryGroupDTO)
+    assert update_group_dto.id == 10
+    assert update_group_dto.unique_identifier == get_summary_group_id(storage_key)
+    assert update_group_dto.name == "update.note"
 
     # Transcript should be added
     mock_summary_service.add_summary.assert_called_once()
     transcript_dto = mock_summary_service.add_summary.call_args.args[1]
     assert transcript_dto.unique_identifier == get_transcript_id(storage_key)
+    assert transcript_dto.parent_unique_identifier == get_summary_group_id(storage_key)
 
     # AI Summary should be updated
     mock_summary_service.update_summary.assert_called_once()
@@ -248,6 +287,7 @@ async def test_summary_idempotency_update(
     update_dto = update_call.args[1]
 
     assert update_dto.id == existing_summary.id
+    assert update_dto.parent_unique_identifier == get_summary_group_id(storage_key)
     assert "## 2023-10-28 (Pages 3, 4)" in update_dto.content
     assert "New AI Summary" in update_dto.content
 
@@ -300,9 +340,16 @@ async def test_summary_transcript_with_dates(
     # Run full module lifecycle
     await summary_module.run(file_id, session_manager)
 
-    # Verify Transcript contains date and metadata
+    # Verify Group was created
+    mock_summary_service.add_group.assert_called_once()
+    group_dto = mock_summary_service.add_group.call_args.args[1]
+    assert group_dto.unique_identifier == get_summary_group_id(storage_key)
+    assert group_dto.name == "dates.note"
+
+    # Verify Transcript contains date and metadata and parent_unique_identifier
     transcript_call = mock_summary_service.add_summary.call_args_list[0]
     dto = transcript_call.args[1]
+    assert dto.parent_unique_identifier == get_summary_group_id(storage_key)
     assert "--- Page 1 ---" in dto.content
     assert "Page ID: P20231027120000abc" in dto.content
     assert "Page Date (Inferred): 2023-10-27" in dto.content

--- a/tests/server/utils/test_paths.py
+++ b/tests/server/utils/test_paths.py
@@ -1,0 +1,63 @@
+import uuid
+from unittest.mock import patch
+
+from supernote.server.utils.paths import (
+    generate_inner_name,
+    get_conversion_pdf_path,
+    get_conversion_png_path,
+    get_file_chunk_path,
+    get_page_png_path,
+    get_summary_group_id,
+    get_summary_id,
+    get_transcript_id,
+)
+
+
+def test_get_page_png_path() -> None:
+    assert get_page_png_path(123, "page_1") == "123/pages/page_1.png"
+
+
+def test_get_file_chunk_path() -> None:
+    assert get_file_chunk_path("file_obj", 2) == "file_obj.part.2"
+
+
+def test_get_summary_id() -> None:
+    assert get_summary_id("file_key") == "file_key-summary"
+
+
+def test_get_summary_group_id() -> None:
+    assert get_summary_group_id("file_key") == "file_key-group"
+
+
+def test_get_transcript_id() -> None:
+    assert get_transcript_id("file_key") == "file_key-transcript"
+
+
+def test_get_conversion_png_path() -> None:
+    assert (
+        get_conversion_png_path(1, 2, 3, "md5hash")
+        == "conversions/1/2/page_3_md5hash.png"
+    )
+
+
+def test_get_conversion_pdf_path() -> None:
+    assert (
+        get_conversion_pdf_path(1, 2, "md5hash") == "conversions/1/2/note_md5hash.pdf"
+    )
+
+
+def test_generate_inner_name() -> None:
+    fixed_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    with patch("uuid.uuid4", return_value=fixed_uuid):
+        assert (
+            generate_inner_name("document.pdf", "DEVICE123")
+            == "12345678-1234-5678-1234-567812345678-123.pdf"
+        )
+        assert (
+            generate_inner_name("note.note", "12")
+            == "12345678-1234-5678-1234-567812345678-12.note"
+        )
+        assert (
+            generate_inner_name("note.note", None)
+            == "12345678-1234-5678-1234-567812345678-000.note"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "supernote"
-version = "0.17.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "colour" },


### PR DESCRIPTION
## Description

Fixes #233.

In the Supernote ecosystem and Partner App, digests belonging to the same notebook/document are grouped under a parent `SummaryGroup` (`is_summary_group="Y"` / `True`). Previously, `SummaryModule` produced root-level summaries (`parent_unique_identifier=None`) for raw OCR transcripts and Gemini summaries, leading to an unorganized flat digest list in the app.

### Changes
1. **Identifier Utilities**:
   - Added `get_summary_group_id(file_basis: str) -> str` in `supernote.server.utils.paths` returning `{file_basis}-group`.
2. **Processor Module**:
   - Implemented `_upsert_group` in `SummaryModule` to ensure a `SummaryGroup` exists for each note before adding/updating summaries.
   - Linked both the OCR transcript (`{file_basis}-transcript`) and AI summary (`{file_basis}-summary`) to the parent group by setting `parent_unique_identifier`.
3. **Summary Service**:
   - Updated `SummaryService.update_summary` to support updating `parent_unique_identifier`, `source_path`, and `data_source` when provided in `UpdateSummaryDTO`.
4. **Testing**:
   - Added `tests/server/utils/test_paths.py` for full 1:1 test parity.
   - Updated unit tests in `test_summary.py` to verify group creation/updates and `parent_unique_identifier` propagation.
   - Updated integration test in `test_processor_integration.py` to assert database group creation and child summary hierarchy.

### Verification
- Full test suite passed (597 tests).
- Ruff check & format verified clean.