### PR TITLE
fix(server): define _SortableItem Protocol and update ty to v0.0.74

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -e .[all]
 coverage==7.15.4
-ty==0.0.69
+ty==0.0.74
 pdoc==16.0.0
 pip==26.2.1
 pre-commit==4.6.2

--- a/supernote/server/routes/file_web.py
+++ b/supernote/server/routes/file_web.py
@@ -2,7 +2,7 @@ import logging
 import urllib.parse
 import uuid
 from pathlib import Path
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 from aiohttp import web
 
@@ -47,14 +47,22 @@ from supernote.server.services.file import (
     FileEntity,
     FileService,
     FolderDetail,
-    RecycleEntity,
 )
 from supernote.server.utils.url_signer import get_request_base_url
 
 logger = logging.getLogger(__name__)
 routes = web.RouteTableDef()
 
-_T = TypeVar("_T", bound=(FileEntity | RecycleEntity))
+
+class _SortableItem(Protocol):
+    name: str
+    size: int
+
+    @property
+    def sort_time(self) -> int: ...
+
+
+_T = TypeVar("_T", bound=_SortableItem)
 
 
 def _sort_and_page(

--- a/uv.lock
+++ b/uv.lock
@@ -1479,7 +1479,7 @@ wheels = [
 
 [[package]]
 name = "supernote"
-version = "0.17.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "colour" },


### PR DESCRIPTION
## Description
- Updates dependency `ty` to `v0.0.74`.
- Defines a `_SortableItem` `Protocol` in `supernote/server/routes/file_web.py` for items passed to `_sort_and_page`.
- Fixes `invalid-attribute-access` diagnostic in `ty` v0.0.74 when accessing `sort_time` descriptor on bounded union `TypeVar`.

Closes #226