### PR TITLE
fix(web): add sha256 fallback for insecure contexts and ensure docker user home (#218)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     SUPERNOTE_HOST=0.0.0.0 \
     SUPERNOTE_PORT=8080
 
-# Create a non-root user
-RUN groupadd -g 1000 -r supernote && useradd -u 1000 -r -g supernote supernote
+# Create a non-root user with a home directory
+RUN groupadd -g 1000 -r supernote && useradd -u 1000 -r -g supernote -m -d /home/supernote supernote
 
 # Install system dependencies for SQL Lite CLI
 RUN apt-get update && \

--- a/supernote/server/static/index.html
+++ b/supernote/server/static/index.html
@@ -7,6 +7,7 @@
     <title>Supernote Cloud - Web Viewer</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/spark-md5/3.0.2/spark-md5.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-sha256/0.11.0/sha256.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico">

--- a/supernote/server/static/js/api/client.js
+++ b/supernote/server/static/js/api/client.js
@@ -72,12 +72,18 @@ export async function login(email, password) {
     return loginData;
 }
 
-// Helper: SHA-256 using Web Crypto API
+// Helper: SHA-256 using Web Crypto API with fallback for non-secure contexts (e.g. plain HTTP on LAN IP)
 async function sha256(message) {
-    const msgBuffer = new TextEncoder().encode(message);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    if (window.crypto && window.crypto.subtle) {
+        const msgBuffer = new TextEncoder().encode(message);
+        const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+        const hashArray = Array.from(new Uint8Array(hashBuffer));
+        return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    }
+    if (typeof window.sha256 === 'function') {
+        return window.sha256(message);
+    }
+    throw new Error("SHA-256 is not available. Please access via HTTPS/localhost or ensure js-sha256 is loaded.");
 }
 
 /**

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -174,3 +174,17 @@ async def test_upload_url_with_port_in_forwarded_host(
     assert full_upload_url.startswith("http://localhost:9888"), (
         f"Got URL: {full_upload_url}"
     )
+
+
+async def test_static_frontend_sha256_fallback(client: TestClient) -> None:
+    """Verify that index.html and client.js include fallback for SHA-256 in insecure contexts."""
+    resp = await client.get("/")
+    assert resp.status == 200
+    html = await resp.text()
+    assert "js-sha256" in html
+
+    resp = await client.get("/static/js/api/client.js")
+    assert resp.status == 200
+    js = await resp.text()
+    assert "crypto.subtle" in js
+    assert "window.sha256" in js


### PR DESCRIPTION
Fixes #218

### Summary
This PR addresses both issues reported in #218:

1. **Browser Web UI SHA-256 Fallback (Primary Issue)**:
   - When accessing the Supernote Web UI over plain HTTP using an IP address (e.g. `http://<LAN_IP>:8080`), modern browsers treat the origin as an insecure context (`window.isSecureContext === false`).
   - In insecure contexts, browsers disable the Web Cryptography API (`window.crypto.subtle` is `undefined`), leading to `TypeError: Cannot read properties of undefined (reading 'digest')` during login challenge hashing.
   - Added `js-sha256` via CDN in `index.html` (matching the existing `spark-md5` CDN pattern) and updated `sha256` in `client.js` to fall back to `window.sha256` when `window.crypto.subtle` is unavailable.

2. **Dockerfile Home Directory**:
   - Updated the `useradd` command in `Dockerfile` with `-m -d /home/supernote` so the `supernote` user is provisioned with a home directory. This allows CLI commands like `supernote cloud-login` inside the container to cache credentials in `~/.cache/supernote.pkl`.

3. **Testing**:
   - Added test in `tests/server/test_app.py` verifying static frontend assets include the fallback dependency.
   - Verified end-to-end in headless Chromium with Playwright that login succeeds and session token is stored when `window.crypto.subtle` is disabled.